### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/near/near-api-rs/compare/v0.2.1...v0.3.0) - 2024-11-19
+
+### Added
+
+- replaced `near-primitives` views with own types ([#11](https://github.com/near/near-api-rs/pull/11))
+
+### Other
+
+- [**breaking**] updates near-* dependencies to 0.27 release ([#13](https://github.com/near/near-api-rs/pull/13))
+- use own re-export
+- block querying, encapsulation improvements. ([#9](https://github.com/near/near-api-rs/pull/9))
+
 ## [0.2.1](https://github.com/near/near-api-rs/compare/v0.2.0...v0.2.1) - 2024-10-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "near-api"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-api"
-version = "0.2.1"
+version = "0.3.0"
 authors = [
     "akorchyn <artur.yurii.korchynskyi@gmail.com>",
     "frol <frolvlad@gmail.com>",


### PR DESCRIPTION
## 🤖 New release
* `near-api`: 0.2.1 -> 0.3.0 (⚠️ API breaking changes)

### ⚠️ `near-api` breaking changes

```
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_missing.ron

Failed in:
  struct near_api::Contract, previously in file /tmp/.tmpP5roVz/near-api/src/contract.rs:27
  struct near_api::Transaction, previously in file /tmp/.tmpP5roVz/near-api/src/transactions.rs:71
  struct near_api::Delegation, previously in file /tmp/.tmpP5roVz/near-api/src/stake.rs:30
  struct near_api::Account, previously in file /tmp/.tmpP5roVz/near-api/src/account/mod.rs:24
  struct near_api::StorageDeposit, previously in file /tmp/.tmpP5roVz/near-api/src/storage.rs:14
  struct near_api::FastNear, previously in file /tmp/.tmpP5roVz/near-api/src/fastnear.rs:63
  struct near_api::NetworkConfig, previously in file /tmp/.tmpP5roVz/near-api/src/config.rs:2
  struct near_api::Staking, previously in file /tmp/.tmpP5roVz/near-api/src/stake.rs:250
  struct near_api::Tokens, previously in file /tmp/.tmpP5roVz/near-api/src/tokens.rs:38
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/near/near-api-rs/compare/v0.2.1...v0.3.0) - 2024-11-19

### Added

- replaced `near-primitives` views with own types ([#11](https://github.com/near/near-api-rs/pull/11))

### Other

- [**breaking**] updates near-* dependencies to 0.27 release ([#13](https://github.com/near/near-api-rs/pull/13))
- use own re-export
- block querying, encapsulation improvements. ([#9](https://github.com/near/near-api-rs/pull/9))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).