### PR TITLE
Make mods public in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,14 @@
-mod account;
-mod chain;
-mod config;
-mod contract;
-mod stake;
-mod storage;
-mod tokens;
-mod transactions;
+pub mod account;
+pub mod chain;
+pub mod config;
+pub mod contract;
+pub mod stake;
+pub mod storage;
+pub mod tokens;
+pub mod transactions;
 
-mod common;
-mod fastnear;
+pub mod common;
+pub mod fastnear;
 
 pub mod errors;
 pub mod signer;


### PR DESCRIPTION
There are mods like transactions, contract, account… which contain useful information to use for folks integrating. Real quick PR to make those public, since I saw this error:

![Screenshot 2024-11-23 at 12 18 47 AM](https://github.com/user-attachments/assets/164079d4-c9f0-42bf-a5ab-d7000d396dad)
