### PR TITLE
refactor!: replaced deploy method as a static method

### DIFF
--- a/examples/deploy_and_call_method.rs
+++ b/examples/deploy_and_call_method.rs
@@ -6,18 +6,21 @@ async fn main() {
     let account = network.dev_create_account().await.unwrap();
     let network = NetworkConfig::from(network);
 
-    let contract = Contract(account.id().clone());
     let signer = Signer::new(Signer::from_workspace(&account)).unwrap();
 
     // Let's deploy the contract. The contract is simple counter with `get_num`, `increase`, `decrease` arguments
-    contract
-        .deploy(include_bytes!("../resources/counter.wasm").to_vec())
-        // You can add init call as well using `with_init_call`
-        .without_init_call()
-        .with_signer(signer.clone())
-        .send_to(&network)
-        .await
-        .unwrap();
+    Contract::deploy(
+        account.id().clone(),
+        include_bytes!("../resources/counter.wasm").to_vec(),
+    )
+    // You can add init call as well using `with_init_call`
+    .without_init_call()
+    .with_signer(signer.clone())
+    .send_to(&network)
+    .await
+    .unwrap();
+
+    let contract = Contract(account.id().clone());
 
     // Let's fetch current value on a contract
     let current_value: Data<i8> = contract

--- a/examples/ft.rs
+++ b/examples/ft.rs
@@ -11,20 +11,22 @@ async fn main() {
     let token_signer = Signer::new(Signer::from_workspace(&token)).unwrap();
 
     // Deploying token contract
-    Contract(token.id().clone())
-        .deploy(include_bytes!("../resources/fungible_token.wasm").to_vec())
-        .with_init_call(
-            "new_default_meta",
-            json!({
-                "owner_id": token.id().to_string(),
-                "total_supply": "1000000000000000000000000000"
-            }),
-        )
-        .unwrap()
-        .with_signer(token_signer.clone())
-        .send_to(&network)
-        .await
-        .unwrap();
+    Contract::deploy(
+        token.id().clone(),
+        include_bytes!("../resources/fungible_token.wasm").to_vec(),
+    )
+    .with_init_call(
+        "new_default_meta",
+        json!({
+            "owner_id": token.id().to_string(),
+            "total_supply": "1000000000000000000000000000"
+        }),
+    )
+    .unwrap()
+    .with_signer(token_signer.clone())
+    .send_to(&network)
+    .await
+    .unwrap();
 
     // Verifying that user has 1000 tokens
     let tokens = Tokens::of(token.id().clone())

--- a/examples/nft.rs
+++ b/examples/nft.rs
@@ -11,23 +11,26 @@ async fn main() {
     let account = network.dev_create_account().await.unwrap();
     let network = NetworkConfig::from(network);
 
-    let contract = Contract(nft.id().clone());
     let nft_signer = Signer::new(Signer::from_workspace(&nft)).unwrap();
 
     // Deploying token contract
-    contract
-        .deploy(include_bytes!("../resources/nft.wasm").to_vec())
-        .with_init_call(
-            "new_default_meta",
-            json!({
-                "owner_id": nft.id().to_string(),
-            }),
-        )
-        .unwrap()
-        .with_signer(nft_signer.clone())
-        .send_to(&network)
-        .await
-        .unwrap();
+    Contract::deploy(
+        nft.id().clone(),
+        include_bytes!("../resources/nft.wasm").to_vec(),
+    )
+    .with_init_call(
+        "new_default_meta",
+        json!({
+            "owner_id": nft.id().to_string(),
+        }),
+    )
+    .unwrap()
+    .with_signer(nft_signer.clone())
+    .send_to(&network)
+    .await
+    .unwrap();
+
+    let contract = Contract(nft.id().clone());
 
     // Mint NFT via contract call
     contract

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -44,8 +44,8 @@ impl Contract {
         })
     }
 
-    pub fn deploy(&self, code: Vec<u8>) -> DeployContractBuilder {
-        DeployContractBuilder::new(self.0.clone(), code)
+    pub fn deploy(contract: AccountId, code: Vec<u8>) -> DeployContractBuilder {
+        DeployContractBuilder::new(contract, code)
     }
 
     pub fn abi(


### PR DESCRIPTION
BREAKING:
Contract(abc.testnet).deploy(code) to Contract::deploy(abc.testnet, code)