### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/near/near-api-rs/compare/v0.3.0...v0.4.0) - 2024-12-19
+
+### Added
+
+- added ability to specify backup rpc for connecting to the network (#28)
+- don't retry on critical errors (query, tx) (#27)
+
+### Other
+
+- updates near-* dependencies to 0.28 release. Removed Cargo.lock (#33)
+- [**breaking**] added documentation for root level and signer module (#32)
+- added CODEOWNERS (#31)
+- removed prelude and filtered entries.  (#29)
+- replaced SecretBuilder with utility functions (#26)
+- [**breaking**] replaced deploy method as a static method (#18)
+
 ## [0.3.0](https://github.com/near/near-api-rs/compare/v0.2.1...v0.3.0) - 2024-11-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-api"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     "akorchyn <artur.yurii.korchynskyi@gmail.com>",
     "frol <frolvlad@gmail.com>",


### PR DESCRIPTION
## 🤖 New release
* `near-api`: 0.3.0 -> 0.4.0 (⚠️ API breaking changes)

### ⚠️ `near-api` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_missing.ron

Failed in:
  enum near_api::prelude::EpochReference, previously in file /tmp/.tmpGaArWl/near-api/src/types/reference.rs:43
  enum near_api::prelude::Reference, previously in file /tmp/.tmpGaArWl/near-api/src/types/reference.rs:10

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_variant_added.ron

Failed in:
  variant ExecuteTransactionError:TransactionError in /tmp/.tmpxj58YP/near-api-rs/src/errors.rs:196

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ExecuteTransactionError::RetriesExhausted, previously in file /tmp/.tmpGaArWl/near-api/src/errors.rs:186

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/function_missing.ron

Failed in:
  function near_api::signer::get_signed_delegate_action, previously in file /tmp/.tmpGaArWl/near-api/src/signer/mod.rs:272

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/inherent_method_missing.ron

Failed in:
  Signer::seed_phrase, previously in file /tmp/.tmpGaArWl/near-api/src/signer/mod.rs:167
  Signer::secret_key, previously in file /tmp/.tmpGaArWl/near-api/src/signer/mod.rs:178
  Signer::seed_phrase_with_hd_path, previously in file /tmp/.tmpGaArWl/near-api/src/signer/mod.rs:182
  Signer::access_keyfile, previously in file /tmp/.tmpGaArWl/near-api/src/signer/mod.rs:191
  Signer::ledger, previously in file /tmp/.tmpGaArWl/near-api/src/signer/mod.rs:196
  Signer::ledger_with_hd_path, previously in file /tmp/.tmpGaArWl/near-api/src/signer/mod.rs:201
  Signer::keystore, previously in file /tmp/.tmpGaArWl/near-api/src/signer/mod.rs:206
  Signer::keystore_search_for_keys, previously in file /tmp/.tmpGaArWl/near-api/src/signer/mod.rs:211

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/module_missing.ron

Failed in:
  mod near_api::prelude, previously in file /tmp/.tmpGaArWl/near-api/src/lib.rs:17

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing, renamed, or changed from const to static.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  W_NEAR_BALANCE in file /tmp/.tmpGaArWl/near-api/src/types/tokens.rs:8
  USDT_BALANCE in file /tmp/.tmpGaArWl/near-api/src/types/tokens.rs:6

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/struct_missing.ron

Failed in:
  struct near_api::prelude::Signer, previously in file /tmp/.tmpGaArWl/near-api/src/signer/mod.rs:91
  struct near_api::prelude::Account, previously in file /tmp/.tmpGaArWl/near-api/src/account/mod.rs:24
  struct near_api::prelude::Chain, previously in file /tmp/.tmpGaArWl/near-api/src/chain.rs:12
  struct near_api::prelude::StorageDeposit, previously in file /tmp/.tmpGaArWl/near-api/src/storage.rs:14
  struct near_api::prelude::Delegation, previously in file /tmp/.tmpGaArWl/near-api/src/stake.rs:30
  struct near_api::prelude::NetworkConfig, previously in file /tmp/.tmpGaArWl/near-api/src/config.rs:2
  struct near_api::prelude::FastNear, previously in file /tmp/.tmpGaArWl/near-api/src/fastnear.rs:63
  struct near_api::prelude::Data, previously in file /tmp/.tmpGaArWl/near-api/src/types/mod.rs:23
  struct near_api::prelude::Staking, previously in file /tmp/.tmpGaArWl/near-api/src/stake.rs:250
  struct near_api::prelude::FTBalance, previously in file /tmp/.tmpGaArWl/near-api/src/types/tokens.rs:11
  struct near_api::prelude::Contract, previously in file /tmp/.tmpGaArWl/near-api/src/contract.rs:27
  struct near_api::prelude::Transaction, previously in file /tmp/.tmpGaArWl/near-api/src/transactions.rs:71
  struct near_api::prelude::Tokens, previously in file /tmp/.tmpGaArWl/near-api/src/tokens.rs:38

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/trait_missing.ron

Failed in:
  trait near_api::prelude::SignerTrait, previously in file /tmp/.tmpGaArWl/near-api/src/signer/mod.rs:52
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/near/near-api-rs/compare/v0.3.0...v0.4.0) - 2024-12-19

### Added

- added ability to specify backup rpc for connecting to the network (#28)
- don't retry on critical errors (query, tx) (#27)

### Other

- updates near-* dependencies to 0.28 release. Removed Cargo.lock (#33)
- [**breaking**] added documentation for root level and signer module (#32)
- added CODEOWNERS (#31)
- removed prelude and filtered entries.  (#29)
- replaced SecretBuilder with utility functions (#26)
- [**breaking**] replaced deploy method as a static method (#18)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).