### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/near/near-api-rs/compare/v0.4.0...v0.5.0) - 2025-03-16
+
+### Added
+
+- added `map` method to query builders ([#45](https://github.com/near/near-api-rs/pull/45))
+- *(types::contract)* add `BuildInfo` field to `ContractSourceMetadata` ([#46](https://github.com/near/near-api-rs/pull/46))
+- [**breaking**] NEP-413 support ([#37](https://github.com/near/near-api-rs/pull/37))
+
+### Other
+
+- [**breaking**] updates near-* dependencies to 0.29 release ([#51](https://github.com/near/near-api-rs/pull/51))
+- added rust backward compatibility job, updated project readme ([#48](https://github.com/near/near-api-rs/pull/48))
+- [**breaking**] documented types ([#44](https://github.com/near/near-api-rs/pull/44))
+- added cargo words to supported dictionary ([#43](https://github.com/near/near-api-rs/pull/43))
+- [**breaking**] added spellcheck ([#42](https://github.com/near/near-api-rs/pull/42))
+- [**breaking**] documented all the builders. API changes ([#39](https://github.com/near/near-api-rs/pull/39))
+- documented network config  ([#35](https://github.com/near/near-api-rs/pull/35))
+
 ## [0.4.0](https://github.com/near/near-api-rs/compare/v0.3.0...v0.4.0) - 2024-12-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-api"
-version = "0.4.0"
+version = "0.5.0"
 rust-version = "1.81"
 authors = [
     "akorchyn <artur.yurii.korchynskyi@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `near-api`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `near-api` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field RPCEndpoint.retry_method in /tmp/.tmpTIImvx/near-api-rs/src/config.rs:33
  field StorageBalance.locked in /tmp/.tmpTIImvx/near-api-rs/src/types/storage.rs:27
  field UserBalance.total in /tmp/.tmpTIImvx/near-api-rs/src/types/tokens.rs:205
  field UserBalance.storage_locked in /tmp/.tmpTIImvx/near-api-rs/src/types/tokens.rs:209
  field ContractSourceMetadata.build_info in /tmp/.tmpTIImvx/near-api-rs/src/types/contract.rs:81

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_missing.ron

Failed in:
  enum near_api::errors::SecretBuilderkError, previously in file /tmp/.tmpdIq8nL/near-api/src/errors.rs:125

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant SignerError:IO in /tmp/.tmpTIImvx/near-api-rs/src/errors.rs:52
  variant AccountCreationError:AccountShouldBeSubAccountOfSignerOrLinkdrop in /tmp/.tmpTIImvx/near-api-rs/src/errors.rs:168
  variant KeyStoreError:TaskExecutionError in /tmp/.tmpTIImvx/near-api-rs/src/errors.rs:91
  variant AccessKeyFileError:PrivatePublicKeyMismatch in /tmp/.tmpTIImvx/near-api-rs/src/errors.rs:76

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_missing.ron

Failed in:
  variant AccountCreationError::AccountShouldBeSubaccountOfSignerOrLinkdrop, previously in file /tmp/.tmpdIq8nL/near-api/src/errors.rs:154

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/inherent_method_missing.ron

Failed in:
  RPCEndpoint::with_exponential_backoff, previously in file /tmp/.tmpdIq8nL/near-api/src/config.rs:52
  RPCEndpoint::with_initial_sleep, previously in file /tmp/.tmpdIq8nL/near-api/src/config.rs:59

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/module_missing.ron

Failed in:
  mod near_api::signer::access_keyfile_signer, previously in file /tmp/.tmpdIq8nL/near-api/src/signer/access_keyfile_signer.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_missing.ron

Failed in:
  struct near_api::signer::access_keyfile_signer::AccessKeyFileSigner, previously in file /tmp/.tmpdIq8nL/near-api/src/signer/access_keyfile_signer.rs:16

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field 0 of struct ApiKey, previously in file /tmp/.tmpdIq8nL/near-api/src/types/mod.rs:30
  field exponential_backoff of struct RPCEndpoint, previously in file /tmp/.tmpdIq8nL/near-api/src/config.rs:13
  field factor of struct RPCEndpoint, previously in file /tmp/.tmpdIq8nL/near-api/src/config.rs:14
  field initial_sleep of struct RPCEndpoint, previously in file /tmp/.tmpdIq8nL/near-api/src/config.rs:15
  field liquid of struct UserBalance, previously in file /tmp/.tmpdIq8nL/near-api/src/types/tokens.rs:90

--- failure struct_pub_field_now_doc_hidden: pub struct field is now #[doc(hidden)] ---

Description:
A pub field of a pub struct is now marked #[doc(hidden)] and is no longer part of the public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_pub_field_now_doc_hidden.ron

Failed in:
  field ApiKey.0 in file /tmp/.tmpTIImvx/near-api-rs/src/types/mod.rs:61

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/trait_method_added.ron

Failed in:
  trait method near_api::signer::SignerTrait::get_secret_key in file /tmp/.tmpTIImvx/near-api-rs/src/signer/mod.rs:340
  trait method near_api::SignerTrait::get_secret_key in file /tmp/.tmpTIImvx/near-api-rs/src/signer/mod.rs:340

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/trait_method_missing.ron

Failed in:
  method tx_and_secret of trait SignerTrait, previously in file /tmp/.tmpdIq8nL/near-api/src/signer/mod.rs:285
  method tx_and_secret of trait SignerTrait, previously in file /tmp/.tmpdIq8nL/near-api/src/signer/mod.rs:285
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/near/near-api-rs/compare/v0.4.0...v0.5.0) - 2025-03-16

### Added

- added `map` method to query builders ([#45](https://github.com/near/near-api-rs/pull/45))
- *(types::contract)* add `BuildInfo` field to `ContractSourceMetadata` ([#46](https://github.com/near/near-api-rs/pull/46))
- [**breaking**] NEP-413 support ([#37](https://github.com/near/near-api-rs/pull/37))

### Other

- [**breaking**] updates near-* dependencies to 0.29 release ([#51](https://github.com/near/near-api-rs/pull/51))
- added rust backward compatibility job, updated project readme ([#48](https://github.com/near/near-api-rs/pull/48))
- [**breaking**] documented types ([#44](https://github.com/near/near-api-rs/pull/44))
- added cargo words to supported dictionary ([#43](https://github.com/near/near-api-rs/pull/43))
- [**breaking**] added spellcheck ([#42](https://github.com/near/near-api-rs/pull/42))
- [**breaking**] documented all the builders. API changes ([#39](https://github.com/near/near-api-rs/pull/39))
- documented network config  ([#35](https://github.com/near/near-api-rs/pull/35))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).