### PR TITLE
feat(types::contract): add `BuildInfo` field to `ContractSourceMetadata`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,7 @@ jobs:
   test:
     needs: cargo-fmt
     strategy:
+      fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest]
         toolchain: [stable]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   clippy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
       run: cargo clippy --all-targets -- -D clippy::all -D clippy::nursery
 
   cargo-fmt:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
       run: cargo fmt --check
 
   cargo-doc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install libudev (Linux only)
       if: runner.os == 'Linux'
-      run: sudo apt-get -y install libudev-dev libsystemd-dev
+      run: sudo apt-get update && sudo apt-get -y install libudev-dev libsystemd-dev
     - name: Run clippy
       run: cargo clippy --all-targets -- -D clippy::all -D clippy::nursery
 
@@ -38,7 +38,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install libudev (Linux only)
       if: runner.os == 'Linux'
-      run: sudo apt-get -y install libudev-dev libsystemd-dev
+      run: sudo apt-get update && sudo apt-get -y install libudev-dev libsystemd-dev
     - name: run cargo doc
       run: RUSTDOCFLAGS="-D warnings" cargo doc
 
@@ -79,7 +79,7 @@ jobs:
     - uses: Swatinem/rust-cache@v1
     - name: Install libudev (Linux only)
       if: runner.os == 'Linux'
-      run: sudo apt-get -y install libudev-dev libsystemd-dev
+      run: sudo apt-get update && sudo apt-get -y install libudev-dev libsystemd-dev
     - name: Check with stable features
       run: cargo check --verbose
     - name: Run tests with unstable features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 repository = "https://github.com/near/near-api-rs"
 description = "Rust library to interact with NEAR Protocol via RPC API"
 
-exclude = ["resources", "examples", "tests"]
+exclude = ["resources", "tests"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/cspell.json
+++ b/cspell.json
@@ -44,7 +44,9 @@
         "ipfs",
         "nep",
         "cid",
-        "wnear"
+        "wnear",
+        "backlinks",
+        "sourcescan"
     ],
     "ignoreRegExpList": [
         // Base58 encoded public key/secret key

--- a/examples/contract_source_metadata.rs
+++ b/examples/contract_source_metadata.rs
@@ -1,5 +1,5 @@
-use std::str::FromStr;
 use near_api::*;
+use std::str::FromStr;
 
 #[tokio::main]
 async fn main() {
@@ -17,7 +17,6 @@ async fn main() {
             expected_json_metadata,
             serde_json::to_string_pretty(&source_metadata.data).expect("no ser err")
         );
-
     }
 }
 

--- a/examples/contract_source_metadata.rs
+++ b/examples/contract_source_metadata.rs
@@ -1,0 +1,57 @@
+use std::str::FromStr;
+use near_api::*;
+
+#[tokio::main]
+async fn main() {
+    for (account_name, expected_json_metadata) in [
+        ("desolate-toad.testnet", FIRST_METADATA),
+        ("fat-fabulous-toad.testnet", SECOND_METADATA),
+    ] {
+        let source_metadata = Contract(AccountId::from_str(account_name).expect("no err"))
+            .contract_source_metadata()
+            .fetch_from_testnet()
+            .await
+            .expect("no network or rpc err");
+
+        assert_eq!(
+            expected_json_metadata,
+            serde_json::to_string_pretty(&source_metadata.data).expect("no ser err")
+        );
+
+    }
+}
+
+const FIRST_METADATA: &str = r#"{
+  "version": "0.1.0",
+  "link": "https://github.com/dj8yfo/quiet_glen",
+  "standards": [
+    {
+      "standard": "nep330",
+      "version": "1.2.0"
+    }
+  ],
+  "build_info": null
+}"#;
+
+const SECOND_METADATA: &str = r#"{
+  "version": "0.1.0",
+  "link": "https://github.com/dj8yfo/quiet_glen/tree/8d8a8a0fe86a1d8eb3bce45f04ab1a65fecf5a1b",
+  "standards": [
+    {
+      "standard": "nep330",
+      "version": "1.2.0"
+    }
+  ],
+  "build_info": {
+    "build_environment": "sourcescan/cargo-near:0.13.3-rust-1.84.0@sha256:722198ddb92d1b82cbfcd3a4a9f7fba6fd8715f4d0b5fb236d8725c4883f97de",
+    "build_command": [
+      "cargo",
+      "near",
+      "build",
+      "non-reproducible-wasm",
+      "--locked"
+    ],
+    "contract_path": "",
+    "source_code_snapshot": "git+https://github.com/dj8yfo/quiet_glen?rev=8d8a8a0fe86a1d8eb3bce45f04ab1a65fecf5a1b"
+  }
+}"#;

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -257,8 +257,8 @@ impl Contract {
     /// The contract source metadata is a standard interface that allows auditing and viewing source code for a deployed smart contract.
     /// Implementation of this standard is purely optional but is recommended for developers whose contracts are open source.
     ///
-    /// # Examples 
-    /// 
+    /// # Examples
+    ///
     /// ```rust,no_run
     /// use near_api::*;
     ///

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -257,7 +257,8 @@ impl Contract {
     /// The contract source metadata is a standard interface that allows auditing and viewing source code for a deployed smart contract.
     /// Implementation of this standard is purely optional but is recommended for developers whose contracts are open source.
     ///
-    /// # Example
+    /// # Examples 
+    /// 
     /// ```rust,no_run
     /// use near_api::*;
     ///
@@ -269,6 +270,10 @@ impl Contract {
     /// println!("Source metadata: {:?}", source_metadata);
     /// # Ok(())
     /// # }
+    /// ```
+    /// A more verbose runnable example is present in `examples/contract_source_metadata.rs`:
+    /// ```rust,no_run
+    #[doc = include_str!("../examples/contract_source_metadata.rs")]
     /// ```
     pub fn contract_source_metadata(
         &self,

--- a/src/types/contract.rs
+++ b/src/types/contract.rs
@@ -97,7 +97,7 @@ pub struct Standard {
     /// ## Examples:
     ///
     /// ```rust,no_run
-    /// # let standard: String =
+    /// # let version: String =
     /// // for initial release
     /// "1.0.0".into()
     /// # ;

--- a/src/types/contract.rs
+++ b/src/types/contract.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 /// The struct provides information about deployed contract's source code and supported standards.
 ///
-/// Contract source metadata follows [**NEP-330 standard**](https://github.com/near/NEPs/blob/master/neps/nep-0330.md) for smart contract verification
+/// Contract source metadata follows [**NEP-330 standard**](https://github.com/near/NEPs/blob/master/neps/nep-0330.md) for smart contracts
 ///
 /// See documentation of [`crate::Contract::contract_source_metadata`] on how to query this for a contract via this crate
 // `rustdoc` clearly lacks functionality of automatic backlinks within a single crate

--- a/src/types/contract.rs
+++ b/src/types/contract.rs
@@ -11,10 +11,6 @@ use serde::{Deserialize, Serialize};
 pub struct ContractSourceMetadata {
     /// Optional version identifier, typically a semantic version
     ///
-    /// **NOTE**:
-    /// As of **NEP-330** standard version **1.2.0**
-    /// this field may or may not be consistent with [`Self::link`] and with [`BuildInfo::source_code_snapshot`], but only [`BuildInfo::source_code_snapshot`] defines source code for formal reproducibility verification, and [`Self::link`] and [`Self::version`] do not
-    ///
     /// ## Examples:
     ///
     /// ```rust,no_run
@@ -27,10 +23,6 @@ pub struct ContractSourceMetadata {
 
     // cSpell::ignore bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq
     /// Optional URL to source code repository/tree
-    ///
-    /// **NOTE**:
-    /// As of **NEP-330** standard version **1.2.0**
-    /// this field may or may not be consistent with [`Self::version`] and with [`BuildInfo::source_code_snapshot`], but only [`BuildInfo::source_code_snapshot`] defines source code for formal reproducibility verification, and [`Self::link`] and [`Self::version`] do not
     ///
     /// ## Examples:
     ///
@@ -109,6 +101,8 @@ mod build_info {
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Clone, PartialEq, Default, Eq, Serialize, Deserialize)]
+    /// Defines all required details for formal WASM build reproducibility verification
+    /// according to [**NEP-330 standard**](https://github.com/near/NEPs/blob/master/neps/nep-0330.md)
     pub struct BuildInfo {
         /// Reference to a reproducible build environment docker image
         ///

--- a/src/types/contract.rs
+++ b/src/types/contract.rs
@@ -19,6 +19,12 @@ pub struct ContractSourceMetadata {
     /// Some("1.0.0".into())
     /// # ;
     /// ```
+    /// ```rust,no_run
+    /// # let version: Option<String> =
+    /// // Git commit
+    /// Some("39f2d2646f2f60e18ab53337501370dc02a5661c".into())
+    /// # ;
+    /// ```
     pub version: Option<String>,
 
     // cSpell::ignore bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq
@@ -29,13 +35,19 @@ pub struct ContractSourceMetadata {
     /// ```rust,no_run
     /// # let link: Option<String> =
     /// // GitHub URL
-    /// Some("https://github.com/near-examples/nft-tutorial".into())
+    /// Some("https://github.com/org/repo/tree/8d8a8a0fe86a1d8eb3bce45f04ab1a65fecf5a1b".into())
     /// # ;
     /// ```
     /// ```rust,no_run
     /// # let link: Option<String> =
     /// // GitHub URL
-    /// Some("https://github.com/org/repo/tree/8d8a8a0fe86a1d8eb3bce45f04ab1a65fecf5a1b".into())
+    /// Some("https://github.com/near-examples/nft-tutorial".into())
+    /// # ;
+    /// ```
+    /// ```rust,no_run
+    /// # let link: Option<String> =
+    /// // IPFS CID
+    /// Some("bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq".into())
     /// # ;
     /// ```
     pub link: Option<String>,
@@ -102,7 +114,7 @@ mod build_info {
 
     #[derive(Debug, Clone, PartialEq, Default, Eq, Serialize, Deserialize)]
     /// Defines all required details for formal WASM build reproducibility verification
-    /// according to [**NEP-330 standard**](https://github.com/near/NEPs/blob/master/neps/nep-0330.md)
+    /// according to [**NEP-330 standard 1.2.0 revision**](https://github.com/near/NEPs/blob/master/neps/nep-0330.md)
     pub struct BuildInfo {
         /// Reference to a reproducible build environment docker image
         ///

--- a/src/types/contract.rs
+++ b/src/types/contract.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 /// The struct provides information about deployed contract's source code and supported standards.
 ///
 /// Contract source metadata follows [**NEP-330 standard**](https://github.com/near/NEPs/blob/master/neps/nep-0330.md) for smart contract verification
-/// 
+///
 /// See documentation of [`crate::Contract::contract_source_metadata`] on how to query this for a contract via this crate
 // `rustdoc` clearly lacks functionality of automatic backlinks within a single crate
 #[derive(Debug, Clone, PartialEq, Default, Eq, Serialize, Deserialize)]
@@ -14,12 +14,12 @@ pub struct ContractSourceMetadata {
     /// **NOTE**:
     /// As of **NEP-330** standard version **1.2.0**
     /// this field may or may not be consistent with [`Self::link`] and with [`BuildInfo::source_code_snapshot`], but only [`BuildInfo::source_code_snapshot`] defines source code for formal reproducibility verification, and [`Self::link`] and [`Self::version`] do not
-    /// 
+    ///
     /// ## Examples:
-    /// 
+    ///
     /// ```rust,no_run
     /// # let version: Option<String> =
-    /// // Semantic version 
+    /// // Semantic version
     /// Some("1.0.0".into())
     /// # ;
     /// ```
@@ -33,16 +33,16 @@ pub struct ContractSourceMetadata {
     /// this field may or may not be consistent with [`Self::version`] and with [`BuildInfo::source_code_snapshot`], but only [`BuildInfo::source_code_snapshot`] defines source code for formal reproducibility verification, and [`Self::link`] and [`Self::version`] do not
     ///
     /// ## Examples:
-    /// 
+    ///
     /// ```rust,no_run
     /// # let link: Option<String> =
-    /// // GitHub URL 
+    /// // GitHub URL
     /// Some("https://github.com/near-examples/nft-tutorial".into())
     /// # ;
     /// ```
     /// ```rust,no_run
     /// # let link: Option<String> =
-    /// // GitHub URL 
+    /// // GitHub URL
     /// Some("https://github.com/org/repo/tree/8d8a8a0fe86a1d8eb3bce45f04ab1a65fecf5a1b".into())
     /// # ;
     /// ```
@@ -51,9 +51,9 @@ pub struct ContractSourceMetadata {
     /// List of supported NEAR standards (NEPs) with their versions
     ///
     /// This field is an addition of **1.1.0** **NEP-330** revision
-    /// 
+    ///
     /// ## Examples:
-    /// 
+    ///
     /// This field will always include NEP-330 itself:
     /// ```rust,no_run
     /// # use near_api::types::contract::Standard;
@@ -72,7 +72,7 @@ pub struct ContractSourceMetadata {
     pub standards: Vec<Standard>,
 
     /// Optional details that are required for formal contract WASM build reproducibility verification
-    /// 
+    ///
     /// This field is an addition of **1.2.0** **NEP-330** revision
     pub build_info: Option<BuildInfo>,
 }
@@ -83,7 +83,7 @@ pub struct Standard {
     /// Standard name in lowercase NEP format
     ///
     /// ## Examples:
-    /// 
+    ///
     /// ```rust,no_run
     /// # let standard: String =
     /// // for fungible tokens

--- a/src/types/contract.rs
+++ b/src/types/contract.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Contract source metadata follows [**NEP-330 standard**](https://github.com/near/NEPs/blob/master/neps/nep-0330.md) for smart contracts
 ///
-/// See documentation of [`crate::Contract::contract_source_metadata`] on how to query this for a contract via this crate
+/// See the documentation of [`Contract::contract_source_metadata`](crate::Contract::contract_source_metadata) on how to query this for a contract via this crate
 // `rustdoc` clearly lacks functionality of automatic backlinks within a single crate
 #[derive(Debug, Clone, PartialEq, Default, Eq, Serialize, Deserialize)]
 pub struct ContractSourceMetadata {

--- a/src/types/contract.rs
+++ b/src/types/contract.rs
@@ -1,30 +1,80 @@
+pub use build_info::BuildInfo;
 use serde::{Deserialize, Serialize};
 
 /// The struct provides information about deployed contract's source code and supported standards.
 ///
-/// Contract source metadata follows [NEP-330 standard](https://github.com/near/NEPs/blob/master/neps/nep-0330.md) for smart contract verification
+/// Contract source metadata follows [**NEP-330 standard**](https://github.com/near/NEPs/blob/master/neps/nep-0330.md) for smart contract verification
+/// 
+/// See documentation of [`crate::Contract::contract_source_metadata`] on how to query this for a contract via this crate
+// `rustdoc` clearly lacks functionality of automatic backlinks within a single crate
 #[derive(Debug, Clone, PartialEq, Default, Eq, Serialize, Deserialize)]
 pub struct ContractSourceMetadata {
-    /// Optional version identifier, typically a commit hash or semantic version
+    /// Optional version identifier, typically a semantic version
     ///
-    /// Examples:
-    /// - Git commit: "39f2d2646f2f60e18ab53337501370dc02a5661c"
-    /// - Semantic version: "1.0.0"
+    /// **NOTE**:
+    /// As of **NEP-330** standard version **1.2.0**
+    /// this field may or may not be consistent with [`Self::link`] and with [`BuildInfo::source_code_snapshot`], but only [`BuildInfo::source_code_snapshot`] defines source code for formal reproducibility verification, and [`Self::link`] and [`Self::version`] do not
+    /// 
+    /// ## Examples:
+    /// 
+    /// ```rust,no_run
+    /// # let version: Option<String> =
+    /// // Semantic version 
+    /// Some("1.0.0".into())
+    /// # ;
+    /// ```
     pub version: Option<String>,
 
     // cSpell::ignore bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq
-    /// Optional URL to source code repository or IPFS CID
+    /// Optional URL to source code repository/tree
     ///
-    /// Examples:
-    /// - GitHub URL: "<https://github.com/near-examples/nft-tutorial>"
-    /// - IPFS CID: "bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq"
+    /// **NOTE**:
+    /// As of **NEP-330** standard version **1.2.0**
+    /// this field may or may not be consistent with [`Self::version`] and with [`BuildInfo::source_code_snapshot`], but only [`BuildInfo::source_code_snapshot`] defines source code for formal reproducibility verification, and [`Self::link`] and [`Self::version`] do not
+    ///
+    /// ## Examples:
+    /// 
+    /// ```rust,no_run
+    /// # let link: Option<String> =
+    /// // GitHub URL 
+    /// Some("https://github.com/near-examples/nft-tutorial".into())
+    /// # ;
+    /// ```
+    /// ```rust,no_run
+    /// # let link: Option<String> =
+    /// // GitHub URL 
+    /// Some("https://github.com/org/repo/tree/8d8a8a0fe86a1d8eb3bce45f04ab1a65fecf5a1b".into())
+    /// # ;
+    /// ```
     pub link: Option<String>,
 
     /// List of supported NEAR standards (NEPs) with their versions
     ///
-    /// Should include NEP-330 itself if implemented:
-    /// `Standard { standard: "nep330".into(), version: "1.1.0".into() }`
+    /// This field is an addition of **1.1.0** **NEP-330** revision
+    /// 
+    /// ## Examples:
+    /// 
+    /// This field will always include NEP-330 itself:
+    /// ```rust,no_run
+    /// # use near_api::types::contract::Standard;
+    /// # let link: Vec<Standard> =
+    /// // this is always at least 1.1.0
+    /// vec![Standard { standard: "nep330".into(), version: "1.1.0".into() }]
+    /// # ;
+    /// ```
+    /// ```rust,no_run
+    /// # use near_api::types::contract::Standard;
+    /// # let link: Vec<Standard> =
+    /// vec![Standard { standard: "nep330".into(), version: "1.2.0".into() }]
+    /// # ;
+    /// ```
+    // it's a guess it was added as 1.1.0 of nep330, [nep330 1.1.0 standard recording](https://www.youtube.com/watch?v=pBLN9UyE6AA) actually discusses nep351
     pub standards: Vec<Standard>,
+
+    /// Optional details that are required for formal contract WASM build reproducibility verification
+    /// 
+    /// This field is an addition of **1.2.0** **NEP-330** revision
+    pub build_info: Option<BuildInfo>,
 }
 
 /// NEAR Standard implementation descriptor following [NEP-330](https://github.com/near/NEPs/blob/master/neps/nep-0330.md)    
@@ -32,11 +82,85 @@ pub struct ContractSourceMetadata {
 pub struct Standard {
     /// Standard name in lowercase NEP format
     ///
-    /// Example: "nep141" for fungible tokens
+    /// ## Examples:
+    /// 
+    /// ```rust,no_run
+    /// # let standard: String =
+    /// // for fungible tokens
+    /// "nep141".into()
+    /// # ;
+    /// ```
     pub standard: String,
 
     /// Implemented standard version using semantic versioning
     ///
-    /// Example: "1.0.0" for initial release
+    /// ## Examples:
+    ///
+    /// ```rust,no_run
+    /// # let standard: String =
+    /// // for initial release
+    /// "1.0.0".into()
+    /// # ;
+    /// ```
     pub version: String,
+}
+
+mod build_info {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, PartialEq, Default, Eq, Serialize, Deserialize)]
+    pub struct BuildInfo {
+        /// Reference to a reproducible build environment docker image
+        ///
+        /// ## Examples:
+        ///
+        /// ```rust,no_run
+        /// # let build_environment: String =  
+        ///  "sourcescan/cargo-near:0.13.3-rust-1.84.0@sha256:722198ddb92d1b82cbfcd3a4a9f7fba6fd8715f4d0b5fb236d8725c4883f97de".into()
+        /// # ;
+        /// ```
+        pub build_environment: String,
+        /// The exact command that was used to build the contract, with all the flags
+        ///
+        /// ## Examples:
+        ///
+        /// ```rust,no_run
+        /// # let build_command: Vec<String> =
+        /// vec![
+        ///     "cargo".into(),
+        ///     "near".into(),
+        ///     "build".into(),
+        ///     "non-reproducible-wasm".into(),
+        ///     "--locked".into()
+        /// ]
+        /// # ;
+        /// ```
+        pub build_command: Vec<String>,
+        /// Relative path to contract crate within the source code
+        ///
+        /// ## Examples:
+        ///
+        /// ```rust,no_run
+        /// # let contract_path: String =
+        /// "near/omni-prover/wormhole-omni-prover-proxy".into()
+        /// # ;
+        /// ```
+        /// ```rust,no_run
+        /// # let contract_path: String =
+        /// // root of a repo
+        /// "".into()
+        /// # ;
+        /// ```
+        pub contract_path: String,
+        /// Reference to the source code snapshot that was used to build the contract
+        ///
+        /// ## Examples:
+        ///
+        /// ```rust,no_run
+        /// # let source_code_snapshot: String =
+        /// "git+https://github.com/org/repo?rev=8d8a8a0fe86a1d8eb3bce45f04ab1a65fecf5a1b".into()
+        /// # ;
+        /// ```
+        pub source_code_snapshot: String,
+    }
 }


### PR DESCRIPTION
`--verbose` flag for tests and check jobs might be disabled, as it usually only makes the ci log harder to scroll, without other useful effects