### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/near/near-api-rs/compare/v0.5.0...v0.6.0) - 2025-05-16
+
+### Added
+
+- [**breaking**] added support for the s Global Contracts (NEP-591) ([#56](https://github.com/near/near-api-rs/pull/56))
+- [**breaking**] add field output_wasm_path to ContractSourceMetadata ([#55](https://github.com/near/near-api-rs/pull/55))
+- add issues & prs to devtools project ([#52](https://github.com/near/near-api-rs/pull/52))
+
+### Fixed
+
+- allow forks to leverage transfer-to-project workflow ([#54](https://github.com/near/near-api-rs/pull/54))
+
+### Other
+
+- [**breaking**] updates near-* dependencies to 0.30 release ([#59](https://github.com/near/near-api-rs/pull/59))
+- *(near-contract-standards)* deserialize ContractSourceMetadata::standards field so, as if it were optional 
+
 ## [0.5.0](https://github.com/near/near-api-rs/compare/v0.4.0...v0.5.0) - 2025-03-16
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-api"
-version = "0.5.0"
+version = "0.6.0"
 rust-version = "1.85"
 authors = [
     "akorchyn <artur.yurii.korchynskyi@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `near-api`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)

### ⚠ `near-api` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field BuildInfo.output_wasm_path in /tmp/.tmpxqBgTv/near-api-rs/src/types/contract.rs:185

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/method_parameter_count_changed.ron

Failed in:
  near_api::Contract::deploy now takes 1 parameters instead of 2, in /tmp/.tmpxqBgTv/near-api-rs/src/contract.rs:143
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.0](https://github.com/near/near-api-rs/compare/v0.5.0...v0.6.0) - 2025-05-16

### Added

- [**breaking**] added support for the s Global Contracts (NEP-591) ([#56](https://github.com/near/near-api-rs/pull/56))
- [**breaking**] add field output_wasm_path to ContractSourceMetadata ([#55](https://github.com/near/near-api-rs/pull/55))
- add issues & prs to devtools project ([#52](https://github.com/near/near-api-rs/pull/52))

### Fixed

- allow forks to leverage transfer-to-project workflow ([#54](https://github.com/near/near-api-rs/pull/54))

### Other

- [**breaking**] updates near-* dependencies to 0.30 release ([#59](https://github.com/near/near-api-rs/pull/59))
- *(near-contract-standards)* deserialize ContractSourceMetadata::standards field so, as if it were optional
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).