### PR TITLE
feat!: add field output_wasm_path to ContractSourceMetadata

### DIFF
--- a/examples/contract_source_metadata.rs
+++ b/examples/contract_source_metadata.rs
@@ -51,6 +51,7 @@ const SECOND_METADATA: &str = r#"{
       "--locked"
     ],
     "contract_path": "",
-    "source_code_snapshot": "git+https://github.com/dj8yfo/quiet_glen?rev=8d8a8a0fe86a1d8eb3bce45f04ab1a65fecf5a1b"
+    "source_code_snapshot": "git+https://github.com/dj8yfo/quiet_glen?rev=8d8a8a0fe86a1d8eb3bce45f04ab1a65fecf5a1b",
+    "output_wasm_path": null
   }
 }"#;

--- a/src/types/contract.rs
+++ b/src/types/contract.rs
@@ -168,5 +168,19 @@ mod build_info {
         /// # ;
         /// ```
         pub source_code_snapshot: String,
+        /// A path within the build environment, where the result WASM binary has been put
+        /// during build.
+        /// This should be a subpath of `/home/near/code`
+        ///
+        /// This field is an addition of **1.3.0** **NEP-330** revision
+        ///
+        /// ## Examples:
+        ///
+        /// ```rust,no_run
+        /// # let output_wasm_path: Option<String> =
+        /// Some("/home/near/code/target/near/simple_package.wasm".into())
+        /// # ;
+        /// ```
+        pub output_wasm_path: Option<String>,
     }
 }

--- a/src/types/contract.rs
+++ b/src/types/contract.rs
@@ -114,7 +114,7 @@ mod build_info {
 
     #[derive(Debug, Clone, PartialEq, Default, Eq, Serialize, Deserialize)]
     /// Defines all required details for formal WASM build reproducibility verification
-    /// according to [**NEP-330 standard 1.2.0 revision**](https://github.com/near/NEPs/blob/master/neps/nep-0330.md)
+    /// according to [**NEP-330 standard 1.3.0 revision**](https://github.com/near/NEPs/blob/master/neps/nep-0330.md)
     pub struct BuildInfo {
         /// Reference to a reproducible build environment docker image
         ///


### PR DESCRIPTION
essentially a duplicate of https://github.com/near/near-sdk-rs/pull/1344