### PR TITLE
fix: Fixed compilation errors when latest near-sdk-rs is used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ near-crypto = "0.30"
 near-primitives = "0.30"
 near-jsonrpc-client = "0.17"
 near-jsonrpc-primitives = "0.30"
-near-contract-standards = "5.14"
-near-sdk = "5.14"
+near-contract-standards = "5.15.1"
+near-sdk = { version = "5.15.1", features = ["non-contract-usage"] }
 
 near-account-id = "1.0.0"
 near-gas = { version = "0.3", features = ["serde", "borsh"] }

--- a/examples/ft.rs
+++ b/examples/ft.rs
@@ -34,7 +34,7 @@ async fn main() {
         .await
         .unwrap();
 
-    println!("Owner has {}", tokens);
+    println!("Owner has {tokens}");
 
     // Transfer 100 tokens to the account
     // We handle internally the storage deposit for the receiver account
@@ -59,7 +59,7 @@ async fn main() {
         .await
         .unwrap();
 
-    println!("Account has {}", tokens);
+    println!("Account has {tokens}");
 
     let tokens = Tokens::account(token.id().clone())
         .ft_balance(token.id().clone())
@@ -68,7 +68,7 @@ async fn main() {
         .await
         .unwrap();
 
-    println!("Owner has {}", tokens);
+    println!("Owner has {tokens}");
 
     // We validate decimals at the network level so this should fail with a validation error
     let token = Tokens::account(token.id().clone())

--- a/examples/nep_413_signing_message.rs
+++ b/examples/nep_413_signing_message.rs
@@ -29,5 +29,5 @@ async fn main() {
         .await
         .unwrap();
 
-    println!("Signature: {}", signature);
+    println!("Signature: {signature}");
 }

--- a/examples/sign_options.rs
+++ b/examples/sign_options.rs
@@ -49,5 +49,5 @@ async fn main() {
         .unwrap();
 
     // Should contain 2 keys: new key from seed phrase, and ledger key
-    println!("{:#?}", keys);
+    println!("{keys:#?}");
 }

--- a/src/signer/keystore.rs
+++ b/src/signer/keystore.rs
@@ -101,7 +101,7 @@ impl KeystoreSigner {
         trace!(target: KEYSTORE_SIGNER_TARGET, "Retrieving secret key from keyring");
         let service_name =
             std::borrow::Cow::Owned(format!("near-{}-{}", network_name, account_id.as_str()));
-        let user = format!("{}:{}", account_id, public_key);
+        let user = format!("{account_id}:{public_key}");
 
         // This can be a blocking operation (for example, if the keyring is locked in the OS and user needs to unlock it),
         // so we need to spawn a new task to get the password

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -156,7 +156,7 @@ impl TryFrom<Vec<u8>> for CryptoHash {
 
 impl std::fmt::Debug for CryptoHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 

--- a/src/types/signed_delegate_action.rs
+++ b/src/types/signed_delegate_action.rs
@@ -29,7 +29,7 @@ impl std::fmt::Display for SignedDelegateActionAsBase64 {
             &borsh::to_vec(&self.inner)
                 .expect("Signed Delegate Action serialization to borsh is not expected to fail"),
         );
-        write!(f, "{}", base64_signed_delegate_action)
+        write!(f, "{base64_signed_delegate_action}")
     }
 }
 


### PR DESCRIPTION
Since this repo has `Cargo.lock` ignored, latest near-api version started using near-sdk v5.15.1 which throws compilation error if compiled without `cargo-near`. Since this crate can be used in non-contract environment, it's better to add `non-contract-usage` feature flag for `near-sdk` crate to fix compilation issue
 