### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/near/near-api-rs/compare/v0.6.0...v0.6.1) - 2025-07-05
+
+### Fixed
+
+- Fixed compilation errors when latest near-sdk-rs is used ([#62](https://github.com/near/near-api-rs/pull/62))
+
 ## [0.6.0](https://github.com/near/near-api-rs/compare/v0.5.0...v0.6.0) - 2025-05-16
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-api"
-version = "0.6.0"
+version = "0.6.1"
 rust-version = "1.85"
 authors = [
     "akorchyn <artur.yurii.korchynskyi@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `near-api`: 0.6.0 -> 0.6.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.1](https://github.com/near/near-api-rs/compare/v0.6.0...v0.6.1) - 2025-07-05

### Fixed

- Fixed compilation errors when latest near-sdk-rs is used ([#62](https://github.com/near/near-api-rs/pull/62))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).