### PR TITLE
Add Borsh deserialization support for contract calls

### DIFF
--- a/api/src/common/query/handlers/mod.rs
+++ b/api/src/common/query/handlers/mod.rs
@@ -1,3 +1,4 @@
+use borsh::BorshDeserialize;
 use near_api_types::{
     AccessKey, Account, AccountView, ContractCodeView, Data, PublicKey, RpcBlockResponse,
     RpcValidatorResponse, ViewStateResult, json::U64,
@@ -6,7 +7,6 @@ use near_openapi_client::types::RpcQueryResponse;
 use serde::de::DeserializeOwned;
 use std::marker::PhantomData;
 use tracing::{info, trace, warn};
-use borsh::BorshDeserialize;
 
 use crate::{
     advanced::{

--- a/api/src/contract.rs
+++ b/api/src/contract.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use borsh::BorshDeserialize;
 use near_api_types::{
     AccountId, Action, CryptoHash, Data, FunctionArgs, NearGas, NearToken, Reference, StoreKey,
     contract::ContractSourceMetadata,
@@ -9,13 +10,13 @@ use near_api_types::{
     },
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use borsh::BorshDeserialize;
 
 use crate::{
     advanced::{query_request::QueryRequest, query_rpc::SimpleQueryRpc},
     common::{
         query::{
-            CallResultHandler, CallResultBorshHandler, PostprocessHandler, QueryBuilder, ViewCodeHandler, ViewStateHandler,
+            CallResultBorshHandler, CallResultHandler, PostprocessHandler, QueryBuilder,
+            ViewCodeHandler, ViewStateHandler,
         },
         send::ExecuteSignedTransaction,
         utils::to_base64,


### PR DESCRIPTION
## Summary
- Adds `CallResultBorshHandler` for deserializing Borsh-encoded contract responses
- Adds `read_only_borsh()` method to `CallFunctionBuilder`
- Enables support for contracts that return Borsh data instead of JSON

## Usage
```rust
// Current JSON approach
let result: Data<MyJsonStruct> = contract
    .call_function("my_method", args)?
    .read_only()
    .fetch_from_testnet()
    .await?;

// New Borsh approach  
let result: Data<u64> = contract
    .call_function("my_method", args)?
    .read_only_borsh()
    .fetch_from_testnet()
    .await?;
```