### PR TITLE
fix(types): do not encode in base64 twice

### DIFF
--- a/types/src/transaction/result.rs
+++ b/types/src/transaction/result.rs
@@ -491,9 +491,9 @@ impl ExecutionOutcome {
     /// particular outcome has failed or not.
     pub fn into_result(self) -> Result<ValueOrReceiptId, ExecutionError> {
         match self.status {
-            ExecutionStatusView::SuccessValue(value) => Ok(ValueOrReceiptId::Value(
-                Value::from_string(value),
-            )),
+            ExecutionStatusView::SuccessValue(value) => {
+                Ok(ValueOrReceiptId::Value(Value::from_string(value)))
+            }
             ExecutionStatusView::SuccessReceiptId(hash) => {
                 Ok(ValueOrReceiptId::ReceiptId(hash.try_into()?))
             }


### PR DESCRIPTION
These values are already come base64-encoded, so this breaks JSON and Borsh deserializations after via corresponding `.json()` and `.borsh()` methods