### PR TITLE
chore: release v0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/polyprogrammist/near-openapi-client"
 
 
 [workspace.dependencies]
-near-api-types = { path = "types", version = "0.7.0" }
+near-api-types = { path = "types", version = "0.7.1" }
 
 borsh = "1.5"
 async-trait = "0.1"

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/near/near-api-rs/compare/near-api-v0.7.0...near-api-v0.7.1) - 2025-10-28
+
+### Other
+
+- updated the following local packages: near-api-types
+
 ## [0.7.0](https://github.com/near/near-api-rs/compare/near-api-v0.6.1...near-api-v0.7.0) - 2025-10-13
 
 ### Added

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-api"
-version = "0.7.0"
+version = "0.7.1"
 rust-version = "1.85"
 authors = [
     "akorchyn <artur.yurii.korchynskyi@gmail.com>",

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/near/near-api-rs/compare/near-api-types-v0.7.0...near-api-types-v0.7.1) - 2025-10-28
+
+### Fixed
+
+- *(types)* do not encode in base64 twice ([#71](https://github.com/near/near-api-rs/pull/71))
+
 ## [0.7.0](https://github.com/near/near-api-rs/compare/near-api-types-v0.6.1...near-api-types-v0.7.0) - 2025-10-13
 
 ### Added

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-api-types"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     "akorchyn <artur.yurii.korchynskyi@gmail.com>",
     "frol <frolvlad@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `near-api-types`: 0.7.0 -> 0.7.1 (✓ API compatible changes)
* `near-api`: 0.7.0 -> 0.7.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-api-types`

<blockquote>

## [0.7.1](https://github.com/near/near-api-rs/compare/near-api-types-v0.7.0...near-api-types-v0.7.1) - 2025-10-28

### Fixed

- *(types)* do not encode in base64 twice ([#71](https://github.com/near/near-api-rs/pull/71))
</blockquote>

## `near-api`

<blockquote>

## [0.7.1](https://github.com/near/near-api-rs/compare/near-api-v0.7.0...near-api-v0.7.1) - 2025-10-28

### Other

- updated the following local packages: near-api-types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).