### PR TITLE
feat: added `call_function_raw` and `call_function_borsh` and `max_gas` functions

### DIFF
--- a/api/src/errors.rs
+++ b/api/src/errors.rs
@@ -149,6 +149,8 @@ pub enum SecretBuilderError<E: std::fmt::Debug> {
 pub enum BuilderError {
     #[error("Incorrect arguments: {0}")]
     IncorrectArguments(#[from] serde_json::Error),
+    #[error("Borsh serialization error: {0}")]
+    SerializationError(#[from] std::io::Error),
 }
 
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
* Allows encoding input arguments to the call with borsh or using pre-serialized bytes
* Adds utility function to use max_gas value without requirements to set 300 TGas
@race-of-sloths