### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/polyprogrammist/near-openapi-client"
 
 
 [workspace.dependencies]
-near-api-types = { path = "types", version = "0.7.2" }
+near-api-types = { path = "types", version = "0.7.3" }
 
 borsh = "1.5"
 async-trait = "0.1"

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.7](https://github.com/near/near-api-rs/compare/near-api-v0.7.6...near-api-v0.7.7) - 2025-11-10
+
+### Added
+
+- helper methods to improve dev and test experience ([#83](https://github.com/near/near-api-rs/pull/83))
+- added `global_wasm` method to Contract struct ([#81](https://github.com/near/near-api-rs/pull/81))
+
 ## [0.7.6](https://github.com/near/near-api-rs/compare/near-api-v0.7.5...near-api-v0.7.6) - 2025-11-03
 
 ### Other

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-api"
-version = "0.7.6"
+version = "0.7.7"
 rust-version = "1.85"
 resolver = "2"
 authors.workspace = true

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3](https://github.com/near/near-api-rs/compare/near-api-types-v0.7.2...near-api-types-v0.7.3) - 2025-11-10
+
+### Added
+
+- added assert_failure method similar to assert_success
+- helper methods to improve dev and test experience ([#83](https://github.com/near/near-api-rs/pull/83))
+
 ## [0.7.2](https://github.com/near/near-api-rs/compare/near-api-types-v0.7.1...near-api-types-v0.7.2) - 2025-11-03
 
 ### Other

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-api-types"
-version = "0.7.2"
+version = "0.7.3"
 resolver = "2"
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `near-api-types`: 0.7.2 -> 0.7.3 (✓ API compatible changes)
* `near-api`: 0.7.6 -> 0.7.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-api-types`

<blockquote>

## [0.7.3](https://github.com/near/near-api-rs/compare/near-api-types-v0.7.2...near-api-types-v0.7.3) - 2025-11-10

### Added

- added assert_failure method similar to assert_success
- helper methods to improve dev and test experience ([#83](https://github.com/near/near-api-rs/pull/83))
</blockquote>

## `near-api`

<blockquote>

## [0.7.7](https://github.com/near/near-api-rs/compare/near-api-v0.7.6...near-api-v0.7.7) - 2025-11-10

### Added

- helper methods to improve dev and test experience ([#83](https://github.com/near/near-api-rs/pull/83))
- added `global_wasm` method to Contract struct ([#81](https://github.com/near/near-api-rs/pull/81))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).