### PR TITLE
feat: add ergonomic API for global contracts

### DIFF
--- a/api/examples/global_deploy.rs
+++ b/api/examples/global_deploy.rs
@@ -31,7 +31,7 @@ async fn main() {
 
     // Publish contract code as immutable hash
     Contract::publish_contract(code.clone(), None)
-        .from_signer_account()
+        .from_any_account()
         .with_signer(global.account_id.clone(), global_signer.clone())
         .send_to(&network)
         .await
@@ -40,8 +40,8 @@ async fn main() {
 
     // Publish contract code as mutable account ID
     Contract::publish_contract(code, Some(global.account_id.clone()))
-        .from_signer_account()
-        .with_signer(global.account_id.clone(), global_signer.clone())
+        .from_account()
+        .with_signer(global_signer.clone())
         .send_to(&network)
         .await
         .unwrap()

--- a/api/examples/global_deploy.rs
+++ b/api/examples/global_deploy.rs
@@ -30,8 +30,8 @@ async fn main() {
     let contract_hash = CryptoHash::hash(&code);
 
     // Publish contract code as immutable hash
-    Contract::publish_contract(code.clone(), None)
-        .from_any_account()
+    Contract::publish_contract(code.clone())
+        .as_hash()
         .with_signer(global.account_id.clone(), global_signer.clone())
         .send_to(&network)
         .await
@@ -39,8 +39,8 @@ async fn main() {
         .assert_success();
 
     // Publish contract code as mutable account ID
-    Contract::publish_contract(code, Some(global.account_id.clone()))
-        .from_account()
+    Contract::publish_contract(code)
+        .as_account(global.account_id.clone())
         .with_signer(global_signer.clone())
         .send_to(&network)
         .await

--- a/api/examples/global_deploy.rs
+++ b/api/examples/global_deploy.rs
@@ -6,10 +6,13 @@ async fn main() {
     let global = GenesisAccount::generate_with_name("global".parse().unwrap());
     let instance_of_global =
         GenesisAccount::generate_with_name("instance_of_global".parse().unwrap());
-    let sandbox = near_sandbox::Sandbox::start_sandbox_with_config(SandboxConfig {
-        additional_accounts: vec![global.clone(), instance_of_global.clone()],
-        ..Default::default()
-    })
+    let sandbox = near_sandbox::Sandbox::start_sandbox_with_config_and_version(
+        SandboxConfig {
+            additional_accounts: vec![global.clone(), instance_of_global.clone()],
+            ..Default::default()
+        },
+        "2.9.0",
+    )
     .await
     .unwrap();
     let network = NetworkConfig::from_rpc_url("sandbox", sandbox.rpc_addr.parse().unwrap());
@@ -26,24 +29,27 @@ async fn main() {
     let code: Vec<u8> = include_bytes!("../resources/counter.wasm").to_vec();
     let contract_hash = CryptoHash::hash(&code);
 
-    Contract::deploy_global_contract_code(code.clone())
-        .as_hash()
+    // Publish contract code as immutable hash
+    Contract::publish_contract(code.clone(), None)
+        .from_signer_account()
         .with_signer(global.account_id.clone(), global_signer.clone())
         .send_to(&network)
         .await
         .unwrap()
         .assert_success();
 
-    Contract::deploy_global_contract_code(code)
-        .as_account_id(global.account_id.clone())
-        .with_signer(global_signer.clone())
+    // Publish contract code as mutable account ID
+    Contract::publish_contract(code, Some(global.account_id.clone()))
+        .from_signer_account()
+        .with_signer(global.account_id.clone(), global_signer.clone())
         .send_to(&network)
         .await
         .unwrap()
         .assert_success();
 
+    // Deploy from published code using account ID reference
     Contract::deploy(instance_of_global.account_id.clone())
-        .use_global_account_id(global.account_id.clone())
+        .deploy_from_published(global.account_id.clone())
         .without_init_call()
         .with_signer(instance_of_global_signer.clone())
         .send_to(&network)
@@ -51,8 +57,9 @@ async fn main() {
         .unwrap()
         .assert_success();
 
+    // Deploy from published code using hash reference
     Contract::deploy(instance_of_global.account_id.clone())
-        .use_global_hash(contract_hash)
+        .deploy_from_published(contract_hash)
         .without_init_call()
         .with_signer(instance_of_global_signer.clone())
         .send_to(&network)

--- a/api/src/contract.rs
+++ b/api/src/contract.rs
@@ -281,6 +281,62 @@ impl Contract {
         DeployBuilder::new(contract)
     }
 
+    /// Publishes contract code to the global contract code storage.
+    ///
+    /// This will allow other users to reference given code as hash or account-id and reduce
+    /// the gas cost for deployment.
+    ///
+    /// Please be aware that the deploy costs 10x more compared to the regular costs and the tokens are burnt
+    /// with no way to get it back.
+    ///
+    /// # Arguments
+    /// * `code` - WASM bytecode to publish
+    /// * `account_id` - Optional account ID for mutable deployment:
+    ///   - `None` = immutable (hash-based)
+    ///   - `Some(account_id)` = mutable (account-based, can be upgraded)
+    ///
+    /// ## Example publishing contract code as immutable hash
+    /// ```rust,no_run
+    /// use near_api::*;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let code = std::fs::read("path/to/your/contract.wasm")?;
+    /// let signer = Signer::new(Signer::from_ledger())?;
+    /// let result = Contract::publish_contract(code, None)  // None = immutable by hash
+    ///     .from_signer_account()
+    ///     .with_signer("some-account.testnet".parse()?, signer)
+    ///     .send_to_testnet()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ## Example publishing contract code as mutable account-id
+    ///
+    /// The account-id version is upgradable and can be changed.
+    /// Please note that every subsequent upgrade will charge full deployment cost.
+    ///
+    /// ```rust,no_run
+    /// use near_api::*;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let code = std::fs::read("path/to/your/contract.wasm")?;
+    /// let signer = Signer::new(Signer::from_ledger())?;
+    /// let result = Contract::publish_contract(code, Some("nft-contract.testnet".parse()?))
+    ///     .from_signer_account()
+    ///     .with_signer(signer)
+    ///     .send_to_testnet()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub const fn publish_contract(
+        code: Vec<u8>,
+        account_id: Option<AccountId>,
+    ) -> PublishContractBuilder {
+        PublishContractBuilder::new(code, account_id)
+    }
+
     /// Prepares a transaction to deploy a code to the global contract code storage.
     ///
     /// This will allow other users to reference given code as hash or account-id and reduce
@@ -324,6 +380,10 @@ impl Contract {
     /// # Ok(())
     /// # }
     /// ```
+    #[deprecated(
+        since = "0.8.0",
+        note = "Use `publish_contract(code, None).from_signer_account()` for hash-based deployment or `publish_contract(code, Some(account_id)).from_signer_account()` for account-based deployment"
+    )]
     pub const fn deploy_global_contract_code(code: Vec<u8>) -> GlobalDeployBuilder {
         GlobalDeployBuilder::new(code)
     }
@@ -537,6 +597,55 @@ impl DeployBuilder {
         )
     }
 
+    /// Deploys a contract from previously published code in the global contract code storage.
+    ///
+    /// Accepts either a code hash (immutable) or account ID (mutable) reference.
+    ///
+    /// # Example deploying from hash
+    /// ```rust,no_run
+    /// use near_api::*;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let signer = Signer::new(Signer::from_ledger())?;
+    /// let code_hash: near_api::CryptoHash = "DxfRbrjT3QPmoANMDYTR6iXPGJr7xRUyDnQhcAWjcoFF".parse()?;
+    /// let result = Contract::deploy("contract.testnet".parse()?)
+    ///     .deploy_from_published(code_hash)
+    ///     .without_init_call()
+    ///     .with_signer(signer)
+    ///     .send_to_testnet()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Example deploying from account ID
+    /// ```rust,no_run
+    /// use near_api::*;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let signer = Signer::new(Signer::from_ledger())?;
+    /// let result = Contract::deploy("contract.testnet".parse()?)
+    ///     .deploy_from_published("nft-contract.testnet".parse()?)
+    ///     .without_init_call()
+    ///     .with_signer(signer)
+    ///     .send_to_testnet()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn deploy_from_published(
+        self,
+        reference: impl IntoGlobalContractRef,
+    ) -> SetDeployActionBuilder {
+        let identifier = reference.into_identifier();
+        SetDeployActionBuilder::new(
+            self.contract,
+            Action::UseGlobalContract(Box::new(UseGlobalContractAction {
+                contract_identifier: identifier,
+            })),
+        )
+    }
+
     // /// Prepares a transaction to deploy a contract to the provided account using a immutable hash reference to the code from the global contract code storage.
     // ///
     // /// # Example
@@ -553,6 +662,10 @@ impl DeployBuilder {
     // ///     .await?;
     // /// # Ok(())
     // /// # }
+    #[deprecated(
+        since = "0.8.0",
+        note = "Use `deploy_from_published(code_hash)` instead"
+    )]
     pub fn use_global_hash(self, global_hash: CryptoHash) -> SetDeployActionBuilder {
         SetDeployActionBuilder::new(
             self.contract,
@@ -581,6 +694,10 @@ impl DeployBuilder {
     // ///     .await?;
     // /// # Ok(())
     // /// # }
+    #[deprecated(
+        since = "0.8.0",
+        note = "Use `deploy_from_published(account_id)` instead"
+    )]
     pub fn use_global_account_id(self, global_account_id: AccountId) -> SetDeployActionBuilder {
         SetDeployActionBuilder::new(
             self.contract,
@@ -763,6 +880,100 @@ impl GlobalDeployBuilder {
                 deploy_mode: GlobalContractDeployMode::AccountId,
             }),
         )
+    }
+}
+
+/// Builder for publishing contract code to the global contract code storage.
+///
+/// Created by [`Contract::publish_contract`]. Allows publishing code either as:
+/// - Immutable (hash-based) when `account_id` is `None`
+/// - Mutable (account-based) when `account_id` is `Some(account_id)`
+#[derive(Clone, Debug)]
+pub struct PublishContractBuilder {
+    code: Vec<u8>,
+    account_id: Option<AccountId>,
+}
+
+impl PublishContractBuilder {
+    pub const fn new(code: Vec<u8>, account_id: Option<AccountId>) -> Self {
+        Self { code, account_id }
+    }
+
+    /// Publishes the contract code from the signer's account.
+    ///
+    /// Returns either a `SelfActionBuilder` (for hash-based deployment) or
+    /// `ConstructTransaction` (for account-based deployment) that can be
+    /// signed and sent to the network.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use near_api::*;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let code = std::fs::read("path/to/your/contract.wasm")?;
+    /// let signer = Signer::new(Signer::from_ledger())?;
+    ///
+    /// // Publish as immutable hash
+    /// Contract::publish_contract(code.clone(), None)
+    ///     .from_signer_account()
+    ///     .with_signer("publisher.testnet".parse()?, signer.clone())
+    ///     .send_to_testnet()
+    ///     .await?;
+    ///
+    /// // Publish as mutable account ID
+    /// Contract::publish_contract(code, Some("nft-contract.testnet".parse()?))
+    ///     .from_signer_account()
+    ///     .with_signer(signer)
+    ///     .send_to_testnet()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn from_signer_account(self) -> SelfActionBuilder {
+        let deploy_mode = match self.account_id {
+            None => GlobalContractDeployMode::CodeHash,
+            Some(_) => GlobalContractDeployMode::AccountId,
+        };
+
+        let action = Action::DeployGlobalContract(DeployGlobalContractAction {
+            code: self.code,
+            deploy_mode,
+        });
+
+        SelfActionBuilder::new().add_action(action)
+    }
+}
+
+/// Trait for types that can reference global contracts.
+///
+/// This trait allows the [`DeployBuilder::deploy_from_published`] method to accept
+/// either a code hash (immutable) or an account ID (mutable) reference to global
+/// contract code.
+///
+/// # Implementations
+/// - [`CryptoHash`] - References immutable global contract by hash
+/// - [`AccountId`] - References mutable global contract by account ID
+/// - [`GlobalContractIdentifier`] - Direct identifier (for advanced usage)
+pub trait IntoGlobalContractRef {
+    /// Converts this type into a [`GlobalContractIdentifier`].
+    fn into_identifier(self) -> GlobalContractIdentifier;
+}
+
+impl IntoGlobalContractRef for CryptoHash {
+    fn into_identifier(self) -> GlobalContractIdentifier {
+        GlobalContractIdentifier::CodeHash(self)
+    }
+}
+
+impl IntoGlobalContractRef for AccountId {
+    fn into_identifier(self) -> GlobalContractIdentifier {
+        GlobalContractIdentifier::AccountId(self)
+    }
+}
+
+impl IntoGlobalContractRef for GlobalContractIdentifier {
+    fn into_identifier(self) -> GlobalContractIdentifier {
+        self
     }
 }
 

--- a/api/tests/global_contracts.rs
+++ b/api/tests/global_contracts.rs
@@ -34,8 +34,8 @@ async fn deploy_global_contract_as_account_id_and_use_it() {
     let base64_code_bytes = BASE64_STANDARD.encode(code_bytes);
 
     Contract::publish_contract(code_bytes.to_vec(), Some(global_contract.account_id.clone()))
-        .from_signer_account()
-        .with_signer(global_contract.account_id.clone(), global_signer.clone())
+        .from_account()
+        .with_signer(global_signer.clone())
         .send_to(&network)
         .await
         .unwrap()
@@ -142,7 +142,7 @@ async fn deploy_global_contract_as_hash_and_use_it() {
     let base64_code = BASE64_STANDARD.encode(&code);
 
     Contract::publish_contract(code.clone(), None)
-        .from_signer_account()
+        .from_any_account()
         .with_signer(global_contract.account_id.clone(), global_signer.clone())
         .send_to(&network)
         .await

--- a/api/tests/global_contracts.rs
+++ b/api/tests/global_contracts.rs
@@ -33,8 +33,8 @@ async fn deploy_global_contract_as_account_id_and_use_it() {
     let code_bytes = include_bytes!("../resources/counter.wasm");
     let base64_code_bytes = BASE64_STANDARD.encode(code_bytes);
 
-    Contract::publish_contract(code_bytes.to_vec(), Some(global_contract.account_id.clone()))
-        .from_account()
+    Contract::publish_contract(code_bytes.to_vec())
+        .as_account(global_contract.account_id.clone())
         .with_signer(global_signer.clone())
         .send_to(&network)
         .await
@@ -141,8 +141,8 @@ async fn deploy_global_contract_as_hash_and_use_it() {
     let hash = CryptoHash::hash(&code);
     let base64_code = BASE64_STANDARD.encode(&code);
 
-    Contract::publish_contract(code.clone(), None)
-        .from_any_account()
+    Contract::publish_contract(code.clone())
+        .as_hash()
         .with_signer(global_contract.account_id.clone(), global_signer.clone())
         .send_to(&network)
         .await

--- a/api/tests/global_contracts.rs
+++ b/api/tests/global_contracts.rs
@@ -20,26 +20,29 @@ async fn deploy_global_contract_as_account_id_and_use_it() {
     ))
     .unwrap();
 
-    let sandbox = near_sandbox::Sandbox::start_sandbox_with_config(SandboxConfig {
-        additional_accounts: vec![global_contract.clone()],
-        ..Default::default()
-    })
+    let sandbox = near_sandbox::Sandbox::start_sandbox_with_config_and_version(
+        SandboxConfig {
+            additional_accounts: vec![global_contract.clone()],
+            ..Default::default()
+        },
+        "2.9.0",
+    )
     .await
     .unwrap();
     let network = NetworkConfig::from_rpc_url("sandbox", sandbox.rpc_addr.parse().unwrap());
     let code_bytes = include_bytes!("../resources/counter.wasm");
     let base64_code_bytes = BASE64_STANDARD.encode(code_bytes);
 
-    Contract::deploy_global_contract_code(code_bytes.to_vec())
-        .as_account_id(global_contract.account_id.clone())
-        .with_signer(global_signer.clone())
+    Contract::publish_contract(code_bytes.to_vec(), Some(global_contract.account_id.clone()))
+        .from_signer_account()
+        .with_signer(global_contract.account_id.clone(), global_signer.clone())
         .send_to(&network)
         .await
         .unwrap()
         .assert_success();
 
     Contract::deploy(global_contract.account_id.clone())
-        .use_global_account_id(global_contract.account_id.clone())
+        .deploy_from_published(global_contract.account_id.clone())
         .without_init_call()
         .with_signer(account_signer.clone())
         .send_to(&network)
@@ -123,10 +126,13 @@ async fn deploy_global_contract_as_hash_and_use_it() {
     .unwrap();
     let account_id: AccountId = DEFAULT_GENESIS_ACCOUNT.into();
 
-    let sandbox = near_sandbox::Sandbox::start_sandbox_with_config(SandboxConfig {
-        additional_accounts: vec![global_contract.clone()],
-        ..Default::default()
-    })
+    let sandbox = near_sandbox::Sandbox::start_sandbox_with_config_and_version(
+        SandboxConfig {
+            additional_accounts: vec![global_contract.clone()],
+            ..Default::default()
+        },
+        "2.9.0",
+    )
     .await
     .unwrap();
     let network = NetworkConfig::from_rpc_url("sandbox", sandbox.rpc_addr.parse().unwrap());
@@ -135,8 +141,8 @@ async fn deploy_global_contract_as_hash_and_use_it() {
     let hash = CryptoHash::hash(&code);
     let base64_code = BASE64_STANDARD.encode(&code);
 
-    Contract::deploy_global_contract_code(code.clone())
-        .as_hash()
+    Contract::publish_contract(code.clone(), None)
+        .from_signer_account()
         .with_signer(global_contract.account_id.clone(), global_signer.clone())
         .send_to(&network)
         .await
@@ -155,7 +161,7 @@ async fn deploy_global_contract_as_hash_and_use_it() {
     );
 
     Contract::deploy(account_id.clone())
-        .use_global_hash(hash)
+        .deploy_from_published(hash)
         .without_init_call()
         .with_signer(account_signer.clone())
         .send_to(&network)


### PR DESCRIPTION
Adds ergonomic API for global contracts matching the semantics from near-sdk-rs [PR #1403](https://github.com/near/near-sdk-rs/pull/1403).

## New API

**Publishing contract code:**
```rust
// Immutable (hash-based)
Contract::publish_contract(code)
    .as_hash()
    .with_signer("publisher.testnet".parse()?, signer)
    .send_to(&network)
    .await?;

// Mutable (account-based)
Contract::publish_contract(code)
    .as_account("nft-template.testnet".parse()?)
    .with_signer(signer)
    .send_to(&network)
    .await?;
```

**Deploying from published code:**
```rust
// Works with both hash and account ID
Contract::deploy(account)
    .deploy_from_published(code_hash)  // or account_id
    .without_init_call()
    .with_signer(signer)
    .send_to(&network)
    .await?;
```

## Changes

- Adds `Contract::publish_contract(code)` with builder pattern
  - `.as_hash()` for immutable deployment
  - `.as_account(account_id)` for mutable deployment (transaction auto-bound to account)
- Adds `DeployBuilder::deploy_from_published(reference)` - unified deployment method
- Adds `IntoGlobalContractRef` trait for type-safe references
- Deprecates old 4-method API (still functional for backward compatibility)
- Fixes global contract tests by using neard 2.9.0 (includes NEP-591 support)

## Benefits

- ✅ **Clear intent**: Choose `.as_hash()` or `.as_account()` at decision point
- ✅ **Correct binding**: `.as_account()` automatically binds transaction to account
- ✅ **Impossible to misuse**: No wrong method to call, no panics
- ✅ **Familiar pattern**: Matches old deprecated API structure

## Migration

Old methods are deprecated but still work:
- `deploy_global_contract_code().as_hash()` → `publish_contract(code).as_hash()`
- `deploy_global_contract_code().as_account_id(id)` → `publish_contract(code).as_account(id)`
- `use_global_hash(hash)` → `deploy_from_published(hash)`
- `use_global_account_id(id)` → `deploy_from_published(id)`