### PR TITLE
chore: release v0.8.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ rust-version = "1.85"
 
 [workspace.package]
 edition = "2021"
-version = "0.8.1"
+version = "0.8.2"
 authors = [
     "akorchyn <artur.yurii.korchynskyi@gmail.com>",
     "frol <frolvlad@gmail.com>",
@@ -16,7 +16,7 @@ repository = "https://github.com/near/near-api-rs"
 
 
 [workspace.dependencies]
-near-api-types = { path = "types", version = "~0.8.1" }
+near-api-types = { path = "types", version = "~0.8.2" }
 
 borsh = "1.5"
 async-trait = "0.1"

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2](https://github.com/near/near-api-rs/compare/near-api-v0.8.1...near-api-v0.8.2) - 2025-12-14
+
+### Fixed
+
+- race in `Signer::fetch_tx_nonce` ([#101](https://github.com/near/near-api-rs/pull/101))
+
 ## [0.8.1](https://github.com/near/near-api-rs/compare/near-api-v0.8.0...near-api-v0.8.1) - 2025-12-11
 
 ### Added

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2](https://github.com/near/near-api-rs/compare/near-api-types-v0.8.1...near-api-types-v0.8.2) - 2025-12-14
+
+### Fixed
+
+- race in `Signer::fetch_tx_nonce` ([#101](https://github.com/near/near-api-rs/pull/101))
+
 ## [0.8.0](https://github.com/near/near-api-rs/compare/near-api-types-v0.7.8...near-api-types-v0.8.0) - 2025-12-04
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `near-api-types`: 0.8.1 -> 0.8.2 (✓ API compatible changes)
* `near-api`: 0.8.1 -> 0.8.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-api-types`

<blockquote>

## [0.8.2](https://github.com/near/near-api-rs/compare/near-api-types-v0.8.1...near-api-types-v0.8.2) - 2025-12-14

### Fixed

- race in `Signer::fetch_tx_nonce` ([#101](https://github.com/near/near-api-rs/pull/101))
</blockquote>

## `near-api`

<blockquote>

## [0.8.2](https://github.com/near/near-api-rs/compare/near-api-v0.8.1...near-api-v0.8.2) - 2025-12-14

### Fixed

- race in `Signer::fetch_tx_nonce` ([#101](https://github.com/near/near-api-rs/pull/101))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).