### PR TITLE
fix: address flaky macOS CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest, warp-macos-latest-arm64-6x]
         toolchain:
           - stable
           - ${{ needs.get_msrv.outputs.version }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ near-openapi-types = "0.6"
 # Dev-dependencies
 near-primitives = { version = "0.34" }
 near-crypto = { version = "0.34" }
-near-sandbox = { version = "0.3.0", features = [
+near-sandbox = { version = "0.3.4", features = [
     "generate",
 ], default-features = false }
 testresult = "0.4"


### PR DESCRIPTION
- Upgrade near-sandbox 0.3.0 → 0.3.4 (includes port retry logic and process cleanup fixes)
- Use `warp-macos-latest-arm64-6x` runner (6 cores vs 3 cores on `macos-latest`)