### PR TITLE
chore: release v0.8.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ rust-version = "1.85"
 
 [workspace.package]
 edition = "2021"
-version = "0.8.2"
+version = "0.8.3"
 authors = [
     "akorchyn <artur.yurii.korchynskyi@gmail.com>",
     "frol <frolvlad@gmail.com>",
@@ -16,7 +16,7 @@ repository = "https://github.com/near/near-api-rs"
 
 
 [workspace.dependencies]
-near-api-types = { path = "types", version = "~0.8.2" }
+near-api-types = { path = "types", version = "~0.8.3" }
 
 borsh = "1.5"
 async-trait = "0.1"

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3](https://github.com/near/near-api-rs/compare/near-api-v0.8.2...near-api-v0.8.3) - 2026-01-21
+
+### Added
+
+- serialize U128 and U64 as JSON strings ([#112](https://github.com/near/near-api-rs/pull/112))
+- support for raw bytes response ([#107](https://github.com/near/near-api-rs/pull/107))
+- updated openapi types to 0.7 ([#104](https://github.com/near/near-api-rs/pull/104))
+
+### Fixed
+
+- use finalized block hash for transaction signing ([#116](https://github.com/near/near-api-rs/pull/116))
+
 ## [0.8.2](https://github.com/near/near-api-rs/compare/near-api-v0.8.1...near-api-v0.8.2) - 2025-12-14
 
 ### Fixed

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3](https://github.com/near/near-api-rs/compare/near-api-types-v0.8.2...near-api-types-v0.8.3) - 2026-01-21
+
+### Added
+
+- serialize U128 and U64 as JSON strings ([#112](https://github.com/near/near-api-rs/pull/112))
+- updated openapi types to 0.7 ([#104](https://github.com/near/near-api-rs/pull/104))
+
 ## [0.8.2](https://github.com/near/near-api-rs/compare/near-api-types-v0.8.1...near-api-types-v0.8.2) - 2025-12-14
 
 ### Fixed


### PR DESCRIPTION



## 🤖 New release

* `near-api-types`: 0.8.2 -> 0.8.3 (✓ API compatible changes)
* `near-api`: 0.8.2 -> 0.8.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-api-types`

<blockquote>

## [0.8.3](https://github.com/near/near-api-rs/compare/near-api-types-v0.8.2...near-api-types-v0.8.3) - 2026-01-21

### Added

- serialize U128 and U64 as JSON strings ([#112](https://github.com/near/near-api-rs/pull/112))
- updated openapi types to 0.7 ([#104](https://github.com/near/near-api-rs/pull/104))
</blockquote>

## `near-api`

<blockquote>

## [0.8.3](https://github.com/near/near-api-rs/compare/near-api-v0.8.2...near-api-v0.8.3) - 2026-01-21

### Added

- serialize U128 and U64 as JSON strings ([#112](https://github.com/near/near-api-rs/pull/112))
- support for raw bytes response ([#107](https://github.com/near/near-api-rs/pull/107))
- updated openapi types to 0.7 ([#104](https://github.com/near/near-api-rs/pull/104))

### Fixed

- use finalized block hash for transaction signing ([#116](https://github.com/near/near-api-rs/pull/116))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).