### PR TITLE
fix: use finalized block hash for transaction signing

### DIFF
--- a/api/src/signer/mod.rs
+++ b/api/src/signer/mod.rs
@@ -120,7 +120,7 @@ use near_api_types::{
         delegate_action::{NonDelegateAction, SignedDelegateAction},
         PrepopulateTransaction, SignedTransaction, Transaction, TransactionV0,
     },
-    AccountId, BlockHeight, CryptoHash, Nonce, PublicKey, SecretKey, Signature,
+    AccountId, BlockHeight, CryptoHash, Nonce, PublicKey, Reference, SecretKey, Signature,
 };
 
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -547,8 +547,6 @@ impl Signer {
         public_key: PublicKey,
         network: &NetworkConfig,
     ) -> Result<(Nonce, CryptoHash, BlockHeight), SignerError> {
-        use near_api_types::Reference;
-
         debug!(target: SIGNER_TARGET, "Fetching transaction nonce");
 
         let nonce_data = crate::account::Account(account_id.clone())


### PR DESCRIPTION
## Summary
- Use `Reference::Final` instead of `Reference::Optimistic` when fetching nonce/block hash for transaction signing
- Prevents "Transaction Expired" errors when sending transactions to load-balanced RPC endpoints

## Problem
When sending transactions concurrently to load-balanced RPC endpoints (like `rpc.testnet.near.org`), different nodes behind the load balancer may be at slightly different chain heights. A transaction signed with a block hash from Node A might be sent to Node B which doesn't know that block yet, causing Node B to reject the transaction as "Expired".

## Solution
Fetch the finalized block hash instead of the optimistic one when signing transactions. Finalized blocks are stable across all nodes in a cluster, eliminating the race condition.

## Related
- Similar fix implemented in near-kit: https://github.com/r-near/near-kit/pull/129
- Discussion: https://nearone.slack.com/archives/C0A64SAMDNG/p1768858886288849