### PR TITLE
chore: release v0.8.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ rust-version = "1.86"
 
 [workspace.package]
 edition = "2024"
-version = "0.8.3"
+version = "0.8.4"
 authors = [
     "akorchyn <artur.yurii.korchynskyi@gmail.com>",
     "frol <frolvlad@gmail.com>",
@@ -16,7 +16,7 @@ repository = "https://github.com/near/near-api-rs"
 
 
 [workspace.dependencies]
-near-api-types = { path = "types", version = "~0.8.3" }
+near-api-types = { path = "types", version = "~0.8.4" }
 
 borsh = "1.5"
 async-trait = "0.1"

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.4](https://github.com/near/near-api-rs/compare/near-api-v0.8.3...near-api-v0.8.4) - 2026-03-03
+
+### Added
+
+- handle minimal tx response for NONE/INCLUDED wait_until ([#128](https://github.com/near/near-api-rs/pull/128))
+
+### Other
+
+- upgrade to Rust edition 2024 ([#118](https://github.com/near/near-api-rs/pull/118))
+
 ## [0.8.3](https://github.com/near/near-api-rs/compare/near-api-v0.8.2...near-api-v0.8.3) - 2026-01-21
 
 ### Added

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.4](https://github.com/near/near-api-rs/compare/near-api-types-v0.8.3...near-api-types-v0.8.4) - 2026-03-03
+
+### Added
+
+- handle minimal tx response for NONE/INCLUDED wait_until ([#128](https://github.com/near/near-api-rs/pull/128))
+- Implement Deref for NonDelegateAction and format output ([#119](https://github.com/near/near-api-rs/pull/119))
+
+### Other
+
+- upgrade to Rust edition 2024 ([#118](https://github.com/near/near-api-rs/pull/118))
+
 ## [0.8.3](https://github.com/near/near-api-rs/compare/near-api-types-v0.8.2...near-api-types-v0.8.3) - 2026-01-21
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `near-api-types`: 0.8.3 -> 0.8.4 (✓ API compatible changes)
* `near-api`: 0.8.3 -> 0.8.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-api-types`

<blockquote>

## [0.8.4](https://github.com/near/near-api-rs/compare/near-api-types-v0.8.3...near-api-types-v0.8.4) - 2026-03-03

### Added

- handle minimal tx response for NONE/INCLUDED wait_until ([#128](https://github.com/near/near-api-rs/pull/128))
- Implement Deref for NonDelegateAction and format output ([#119](https://github.com/near/near-api-rs/pull/119))

### Other

- upgrade to Rust edition 2024 ([#118](https://github.com/near/near-api-rs/pull/118))
</blockquote>

## `near-api`

<blockquote>

## [0.8.4](https://github.com/near/near-api-rs/compare/near-api-v0.8.3...near-api-v0.8.4) - 2026-03-03

### Added

- handle minimal tx response for NONE/INCLUDED wait_until ([#128](https://github.com/near/near-api-rs/pull/128))

### Other

- upgrade to Rust edition 2024 ([#118](https://github.com/near/near-api-rs/pull/118))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).