### PR TITLE
feat: migrate from near-openapi-client to near-openrpc-client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ near-gas = { version = "0.3", features = ["serde", "borsh"] }
 near-token = { version = "0.3", features = ["serde", "borsh"] }
 near-abi = "0.4.2"
 near-ledger = "0.9.1"
-near-openrpc-client = { git = "https://github.com/near/near-openrpc-client-rs.git", branch = "feat/errors-module", default-features = false }
+near-openrpc-client = { version = "0.1.0", default-features = false }
 
 # Dev-dependencies
 near-primitives = { version = "0.34" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [workspace]
 resolver = "3"
 members = ["api", "types"]
-rust-version = "1.86"
 
 [workspace.package]
 edition = "2024"
+rust-version = "1.88"
 version = "0.8.4"
 authors = [
     "akorchyn <artur.yurii.korchynskyi@gmail.com>",
@@ -55,8 +55,7 @@ near-gas = { version = "0.3", features = ["serde", "borsh"] }
 near-token = { version = "0.3", features = ["serde", "borsh"] }
 near-abi = "0.4.2"
 near-ledger = "0.9.1"
-near-openapi-client = "0.7"
-near-openapi-types = "0.7"
+near-openrpc-client = { git = "https://github.com/near/near-openrpc-client-rs.git", default-features = false }
 
 # Dev-dependencies
 near-primitives = { version = "0.34" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ near-gas = { version = "0.3", features = ["serde", "borsh"] }
 near-token = { version = "0.3", features = ["serde", "borsh"] }
 near-abi = "0.4.2"
 near-ledger = "0.9.1"
-near-openrpc-client = { git = "https://github.com/near/near-openrpc-client-rs.git", default-features = false }
+near-openrpc-client = { git = "https://github.com/near/near-openrpc-client-rs.git", branch = "feat/errors-module", default-features = false }
 
 # Dev-dependencies
 near-primitives = { version = "0.34" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["api", "types"]
 
 [workspace.package]
-rust-version = "1.86"
+rust-version = "1.88"
 edition = "2024"
 version = "0.8.5"
 authors = [

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-api"
-rust-version = "1.85"
+rust-version = "1.88"
 version.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -27,7 +27,6 @@ openssl = { workspace = true, features = ["vendored"] }
 bip39 = { workspace = true, features = ["rand"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-serde_dbgfmt.workspace = true
 slipped10.workspace = true
 url.workspace = true
 tokio = { workspace = true, default-features = false, features = ["time"] }
@@ -35,7 +34,7 @@ tracing.workspace = true
 thiserror.workspace = true
 
 near-ledger = { workspace = true, optional = true }
-near-openapi-client.workspace = true
+near-openrpc-client.workspace = true
 near-api-types.workspace = true
 
 zstd.workspace = true

--- a/api/src/account/mod.rs
+++ b/api/src/account/mod.rs
@@ -105,7 +105,7 @@ impl Account {
         crate::stake::Delegation(self.0.clone())
     }
 
-    /// Prepares a query to fetch the [Data](crate::Data)<[AccountView](near_api_types::Account)> with the account information for the given account ID.
+    /// Prepares a query to fetch the [Data](crate::Data)<[Account](near_api_types::Account)> with the account information for the given account ID.
     ///
     /// ## Example
     /// ```rust,no_run

--- a/api/src/account/mod.rs
+++ b/api/src/account/mod.rs
@@ -105,7 +105,7 @@ impl Account {
         crate::stake::Delegation(self.0.clone())
     }
 
-    /// Prepares a query to fetch the [Data](crate::Data)<[AccountView](near_api_types::AccountView)> with the account information for the given account ID.
+    /// Prepares a query to fetch the [Data](crate::Data)<[AccountView](near_api_types::Account)> with the account information for the given account ID.
     ///
     /// ## Example
     /// ```rust,no_run

--- a/api/src/chain.rs
+++ b/api/src/chain.rs
@@ -2,7 +2,7 @@ use near_api_types::{BlockHeight, CryptoHash, Reference};
 
 use crate::{
     advanced::block_rpc::SimpleBlockRpc,
-    common::query::{PostprocessHandler, RequestBuilder, RpcBlockHandler},
+    common::query::{AndThenHandler, PostprocessHandler, RequestBuilder, RpcBlockHandler},
 };
 
 /// Chain-related interactions with the NEAR Protocol
@@ -79,9 +79,9 @@ impl Chain {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn block_hash() -> RequestBuilder<PostprocessHandler<CryptoHash, RpcBlockHandler>> {
+    pub fn block_hash() -> RequestBuilder<AndThenHandler<CryptoHash, RpcBlockHandler>> {
         RequestBuilder::new(SimpleBlockRpc, Reference::Optimistic, RpcBlockHandler)
-            .map(|data| CryptoHash::from(data.header.hash))
+            .and_then(|data| Ok(CryptoHash::try_from(data.header.hash)?))
     }
 
     /// Set ups a query to fetch the [RpcBlockResponse][near_api_types::RpcBlockResponse]

--- a/api/src/common/query/block_rpc.rs
+++ b/api/src/common/query/block_rpc.rs
@@ -1,15 +1,10 @@
 use near_api_types::Reference;
-use near_openapi_client::Client;
-use near_openapi_client::types::{
-    BlockId, ErrorWrapperForRpcBlockError, Finality, JsonRpcRequestForBlock,
-    JsonRpcRequestForBlockMethod, JsonRpcResponseForRpcBlockResponseAndRpcBlockError,
-    RpcBlockError, RpcBlockRequest, RpcBlockResponse,
-};
+use near_openrpc_client::{BlockId, Finality, RpcBlockRequest, RpcBlockResponse};
 
 use crate::common::utils::to_retry_error;
 use crate::{
     NetworkConfig, advanced::RpcType, common::utils::is_critical_blocks_error,
-    config::RetryResponse, errors::SendRequestError,
+    config::RetryResponse, errors::SendRequestError, rpc_client::RpcClient,
 };
 
 #[derive(Clone, Debug)]
@@ -19,13 +14,12 @@ pub struct SimpleBlockRpc;
 impl RpcType for SimpleBlockRpc {
     type RpcReference = Reference;
     type Response = RpcBlockResponse;
-    type Error = RpcBlockError;
     async fn send_query(
         &self,
-        client: &Client,
+        client: &RpcClient,
         _network: &NetworkConfig,
         reference: &Reference,
-    ) -> RetryResponse<RpcBlockResponse, SendRequestError<RpcBlockError>> {
+    ) -> RetryResponse<RpcBlockResponse, SendRequestError> {
         let request = match reference {
             Reference::Optimistic => RpcBlockRequest::Finality(Finality::Optimistic),
             Reference::NearFinal => RpcBlockRequest::Finality(Finality::NearFinal),
@@ -35,41 +29,11 @@ impl RpcType for SimpleBlockRpc {
                 RpcBlockRequest::BlockId(BlockId::CryptoHash((*block_hash).into()))
             }
         };
-        let response = client
-            .block(&JsonRpcRequestForBlock {
-                id: "0".to_string(),
-                jsonrpc: "2.0".to_string(),
-                method: JsonRpcRequestForBlockMethod::Block,
-                params: request,
-            })
-            .await
-            .map(|r| r.into_inner())
-            .map_err(SendRequestError::from);
-
-        match response {
-            Ok(JsonRpcResponseForRpcBlockResponseAndRpcBlockError::Variant0 { result, .. }) => {
-                RetryResponse::Ok(result)
-            }
-            Ok(JsonRpcResponseForRpcBlockResponseAndRpcBlockError::Variant1 { error, .. }) => {
-                let error = SendRequestError::from(error);
-                to_retry_error(error, is_critical_blocks_error)
-            }
-            Err(err) => to_retry_error(err, is_critical_blocks_error),
-        }
-    }
-}
-
-impl From<ErrorWrapperForRpcBlockError> for SendRequestError<RpcBlockError> {
-    fn from(err: ErrorWrapperForRpcBlockError) -> Self {
-        match err {
-            ErrorWrapperForRpcBlockError::InternalError(internal_error) => {
-                Self::InternalError(internal_error)
-            }
-            ErrorWrapperForRpcBlockError::RequestValidationError(
-                rpc_request_validation_error_kind,
-            ) => Self::RequestValidationError(rpc_request_validation_error_kind),
-            ErrorWrapperForRpcBlockError::HandlerError(server_error) => {
-                Self::ServerError(server_error)
+        match client.call::<_, RpcBlockResponse>("block", request).await {
+            Ok(response) => RetryResponse::Ok(response),
+            Err(err) => {
+                let err = SendRequestError::from(err);
+                to_retry_error(err, is_critical_blocks_error)
             }
         }
     }

--- a/api/src/common/query/block_rpc.rs
+++ b/api/src/common/query/block_rpc.rs
@@ -3,8 +3,8 @@ use near_openrpc_client::{BlockId, Finality, RpcBlockRequest, RpcBlockResponse};
 
 use crate::common::utils::to_retry_error;
 use crate::{
-    NetworkConfig, advanced::RpcType, common::utils::is_critical_rpc_error,
-    config::RetryResponse, errors::SendRequestError, rpc_client::RpcClient,
+    NetworkConfig, advanced::RpcType, common::utils::is_critical_rpc_error, config::RetryResponse,
+    errors::SendRequestError, rpc_client::RpcClient,
 };
 
 #[derive(Clone, Debug)]

--- a/api/src/common/query/block_rpc.rs
+++ b/api/src/common/query/block_rpc.rs
@@ -3,7 +3,7 @@ use near_openrpc_client::{BlockId, Finality, RpcBlockRequest, RpcBlockResponse};
 
 use crate::common::utils::to_retry_error;
 use crate::{
-    NetworkConfig, advanced::RpcType, common::utils::is_critical_blocks_error,
+    NetworkConfig, advanced::RpcType, common::utils::is_critical_rpc_error,
     config::RetryResponse, errors::SendRequestError, rpc_client::RpcClient,
 };
 
@@ -33,7 +33,7 @@ impl RpcType for SimpleBlockRpc {
             Ok(response) => RetryResponse::Ok(response),
             Err(err) => {
                 let err = SendRequestError::from(err);
-                to_retry_error(err, is_critical_blocks_error)
+                to_retry_error(err, is_critical_rpc_error)
             }
         }
     }

--- a/api/src/common/query/handlers/mod.rs
+++ b/api/src/common/query/handlers/mod.rs
@@ -1,12 +1,14 @@
 use borsh::BorshDeserialize;
 use near_api_types::{
-    AccessKey, Account, AccountView, ContractCodeView, Data, PublicKey, RpcBlockResponse,
-    RpcValidatorResponse, ViewStateResult, json::U64,
+    AccessKey, Account, Data, PublicKey, RpcBlockResponse, RpcValidatorResponse, json::U64,
 };
-use near_openapi_client::types::RpcQueryResponse;
+use near_openrpc_client::{
+    RpcCallFunctionResponse, RpcViewAccessKeyListResponse, RpcViewAccessKeyResponse,
+    RpcViewAccountResponse, RpcViewCodeResponse, RpcViewStateResponse,
+};
 use serde::de::DeserializeOwned;
 use std::marker::PhantomData;
-use tracing::{info, trace, warn};
+use tracing::{info, trace};
 
 use crate::{
     advanced::{
@@ -19,22 +21,6 @@ use crate::{
 pub mod transformers;
 pub use transformers::*;
 
-const fn query_to_kind(response: &RpcQueryResponse) -> &'static str {
-    match response {
-        RpcQueryResponse::Variant0 { .. } => "ViewAccount",
-        RpcQueryResponse::Variant1 { .. } => "ViewCode",
-        RpcQueryResponse::Variant2 { .. } => "ViewState",
-        RpcQueryResponse::Variant3 { .. } => "CallResult",
-        RpcQueryResponse::Variant4 { .. } => "AccessKey",
-        RpcQueryResponse::Variant5 { .. } => "AccessKeyList",
-        RpcQueryResponse::Variant6 { .. } => "ViewGasKey",
-        RpcQueryResponse::Variant7 { .. } => "ViewGasKeyList",
-
-        #[allow(unreachable_patterns)]
-        _ => "UnknownQueryResponse",
-    }
-}
-
 pub trait ResponseHandler {
     type Response;
     type Query: RpcType;
@@ -43,7 +29,7 @@ pub trait ResponseHandler {
     fn process_response(
         &self,
         responses: Vec<<Self::Query as RpcType>::Response>,
-    ) -> ResultWithMethod<Self::Response, <Self::Query as RpcType>::Error>;
+    ) -> ResultWithMethod<Self::Response>;
     fn request_amount(&self) -> usize {
         1
     }
@@ -67,34 +53,26 @@ where
 
     fn process_response(
         &self,
-        response: Vec<RpcQueryResponse>,
-    ) -> ResultWithMethod<Self::Response, <Self::Query as RpcType>::Error> {
+        response: Vec<serde_json::Value>,
+    ) -> ResultWithMethod<Self::Response> {
         let response = response
             .into_iter()
             .next()
             .ok_or(QueryError::InternalErrorNoResponse)?;
 
-        if let RpcQueryResponse::Variant3 {
-            result,
-            logs: _logs,
-            block_height,
-            block_hash,
-        } = response
-        {
-            trace!(target: QUERY_EXECUTOR_TARGET, "Deserializing CallResult, result size: {} bytes", result.len());
-            let data: Response = serde_json::from_slice(&result)?;
-            Ok(Data {
-                data,
-                block_height,
-                block_hash: block_hash.into(),
-            })
-        } else {
-            warn!(target: QUERY_EXECUTOR_TARGET, "Unexpected response kind: {:?}", response);
-            Err(QueryError::UnexpectedResponse {
-                expected: "CallResult",
-                got: query_to_kind(&response),
-            })
-        }
+        let call_result: RpcCallFunctionResponse = serde_json::from_value(response)
+            .map_err(|e| QueryError::DeserializeError(e))?;
+
+        trace!(target: QUERY_EXECUTOR_TARGET, "Deserializing CallResult, result size: {} bytes", call_result.result.len());
+        let data: Response = serde_json::from_slice(&call_result.result)?;
+        Ok(Data {
+            data,
+            block_height: call_result.block_height,
+            block_hash: call_result
+                .block_hash
+                .try_into()
+                .map_err(|e| QueryError::ConversionError(Box::new(e)))?,
+        })
     }
 }
 
@@ -113,33 +91,25 @@ impl ResponseHandler for CallResultRawHandler {
 
     fn process_response(
         &self,
-        response: Vec<RpcQueryResponse>,
-    ) -> ResultWithMethod<Self::Response, <Self::Query as RpcType>::Error> {
+        response: Vec<serde_json::Value>,
+    ) -> ResultWithMethod<Self::Response> {
         let response = response
             .into_iter()
             .next()
             .ok_or(QueryError::InternalErrorNoResponse)?;
 
-        if let RpcQueryResponse::Variant3 {
-            result,
-            logs: _logs,
-            block_height,
-            block_hash,
-        } = response
-        {
-            trace!(target: QUERY_EXECUTOR_TARGET, "Returning CallResult raw bytes, result size: {} bytes", result.len());
-            Ok(Data {
-                data: result,
-                block_height,
-                block_hash: block_hash.into(),
-            })
-        } else {
-            warn!(target: QUERY_EXECUTOR_TARGET, "Unexpected response kind: {:?}", response);
-            Err(QueryError::UnexpectedResponse {
-                expected: "CallResult",
-                got: query_to_kind(&response),
-            })
-        }
+        let call_result: RpcCallFunctionResponse = serde_json::from_value(response)
+            .map_err(|e| QueryError::DeserializeError(e))?;
+
+        trace!(target: QUERY_EXECUTOR_TARGET, "Returning CallResult raw bytes, result size: {} bytes", call_result.result.len());
+        Ok(Data {
+            data: call_result.result,
+            block_height: call_result.block_height,
+            block_hash: call_result
+                .block_hash
+                .try_into()
+                .map_err(|e| QueryError::ConversionError(Box::new(e)))?,
+        })
     }
 }
 
@@ -161,35 +131,27 @@ where
 
     fn process_response(
         &self,
-        response: Vec<RpcQueryResponse>,
-    ) -> ResultWithMethod<Self::Response, <Self::Query as RpcType>::Error> {
+        response: Vec<serde_json::Value>,
+    ) -> ResultWithMethod<Self::Response> {
         let response = response
             .into_iter()
             .next()
             .ok_or(QueryError::InternalErrorNoResponse)?;
 
-        if let RpcQueryResponse::Variant3 {
-            result,
-            logs: _logs,
-            block_height,
-            block_hash,
-        } = response
-        {
-            trace!(target: QUERY_EXECUTOR_TARGET, "Deserializing CallResult using Borsh, result size: {} bytes", result.len());
-            let data: Response = Response::try_from_slice(&result)
-                .map_err(|e| QueryError::ConversionError(Box::new(e)))?;
-            Ok(Data {
-                data,
-                block_height,
-                block_hash: block_hash.into(),
-            })
-        } else {
-            warn!(target: QUERY_EXECUTOR_TARGET, "Unexpected response kind: {:?}", response);
-            Err(QueryError::UnexpectedResponse {
-                expected: "CallResult",
-                got: query_to_kind(&response),
-            })
-        }
+        let call_result: RpcCallFunctionResponse = serde_json::from_value(response)
+            .map_err(|e| QueryError::DeserializeError(e))?;
+
+        trace!(target: QUERY_EXECUTOR_TARGET, "Deserializing CallResult using Borsh, result size: {} bytes", call_result.result.len());
+        let data: Response = Response::try_from_slice(&call_result.result)
+            .map_err(|e| QueryError::ConversionError(Box::new(e)))?;
+        Ok(Data {
+            data,
+            block_height: call_result.block_height,
+            block_hash: call_result
+                .block_hash
+                .try_into()
+                .map_err(|e| QueryError::ConversionError(Box::new(e)))?,
+        })
     }
 }
 
@@ -202,52 +164,35 @@ impl ResponseHandler for AccountViewHandler {
 
     fn process_response(
         &self,
-        response: Vec<RpcQueryResponse>,
-    ) -> ResultWithMethod<Self::Response, <Self::Query as RpcType>::Error> {
+        response: Vec<serde_json::Value>,
+    ) -> ResultWithMethod<Self::Response> {
         let response = response
             .into_iter()
             .next()
             .ok_or(QueryError::InternalErrorNoResponse)?;
 
-        if let RpcQueryResponse::Variant0 {
-            amount,
-            locked,
-            code_hash,
-            storage_usage,
-            storage_paid_at,
-            block_hash,
-            block_height,
-            global_contract_account_id,
-            global_contract_hash,
-        } = response
-        {
-            info!(
-                target: QUERY_EXECUTOR_TARGET,
-                "Processed ViewAccount response: balance: {}, locked: {}",
-                amount, locked
-            );
-            Ok(Data {
-                data: AccountView {
-                    amount,
-                    locked,
-                    code_hash,
-                    storage_usage,
-                    storage_paid_at,
-                    global_contract_account_id,
-                    global_contract_hash,
-                }
-                .try_into()
+        let account_view: RpcViewAccountResponse = serde_json::from_value(response)
+            .map_err(|e| QueryError::DeserializeError(e))?;
+
+        info!(
+            target: QUERY_EXECUTOR_TARGET,
+            "Processed ViewAccount response: balance: {}, locked: {}",
+            account_view.amount, account_view.locked
+        );
+
+        let block_height = account_view.block_height;
+        let block_hash = account_view
+            .block_hash
+            .clone()
+            .try_into()
+            .map_err(|e| QueryError::ConversionError(Box::new(e)))?;
+
+        Ok(Data {
+            data: Account::try_from(account_view)
                 .map_err(|e| QueryError::ConversionError(Box::new(e)))?,
-                block_height,
-                block_hash: block_hash.into(),
-            })
-        } else {
-            warn!(target: QUERY_EXECUTOR_TARGET, "Unexpected response kind: {:?}", response);
-            Err(QueryError::UnexpectedResponse {
-                expected: "ViewAccount",
-                got: query_to_kind(&response),
-            })
-        }
+            block_height,
+            block_hash,
+        })
     }
 
     fn request_amount(&self) -> usize {
@@ -264,42 +209,37 @@ impl ResponseHandler for AccessKeyListHandler {
 
     fn process_response(
         &self,
-        response: Vec<RpcQueryResponse>,
-    ) -> ResultWithMethod<Self::Response, <Self::Query as RpcType>::Error> {
+        response: Vec<serde_json::Value>,
+    ) -> ResultWithMethod<Self::Response> {
         let response = response
             .into_iter()
             .next()
             .ok_or(QueryError::InternalErrorNoResponse)?;
-        if let RpcQueryResponse::Variant5 {
-            keys,
-            block_height,
-            block_hash,
-        } = response
-        {
-            info!(
-                target: QUERY_EXECUTOR_TARGET,
-                "Processed AccessKeyList response, keys count: {}",
-                keys.len()
-            );
-            Ok(Data {
-                data: keys
-                    .into_iter()
-                    .filter_map(|key| {
-                        let public_key = key.public_key.try_into().ok()?;
-                        let access_key = key.access_key.try_into().ok()?;
-                        Some((public_key, access_key))
-                    })
-                    .collect(),
-                block_height,
-                block_hash: block_hash.into(),
-            })
-        } else {
-            warn!(target: QUERY_EXECUTOR_TARGET, "Unexpected response kind: {:?}", response);
-            Err(QueryError::UnexpectedResponse {
-                expected: "AccessKeyList",
-                got: query_to_kind(&response),
-            })
-        }
+
+        let key_list: RpcViewAccessKeyListResponse = serde_json::from_value(response)
+            .map_err(|e| QueryError::DeserializeError(e))?;
+
+        info!(
+            target: QUERY_EXECUTOR_TARGET,
+            "Processed AccessKeyList response, keys count: {}",
+            key_list.keys.len()
+        );
+        Ok(Data {
+            data: key_list
+                .keys
+                .into_iter()
+                .filter_map(|key| {
+                    let public_key = key.public_key.try_into().ok()?;
+                    let access_key = key.access_key.try_into().ok()?;
+                    Some((public_key, access_key))
+                })
+                .collect(),
+            block_height: key_list.block_height,
+            block_hash: key_list
+                .block_hash
+                .try_into()
+                .map_err(|e| QueryError::ConversionError(Box::new(e)))?,
+        })
     }
 
     fn request_amount(&self) -> usize {
@@ -316,42 +256,36 @@ impl ResponseHandler for AccessKeyHandler {
 
     fn process_response(
         &self,
-        response: Vec<RpcQueryResponse>,
-    ) -> ResultWithMethod<Self::Response, <Self::Query as RpcType>::Error> {
+        response: Vec<serde_json::Value>,
+    ) -> ResultWithMethod<Self::Response> {
         let response = response
             .into_iter()
             .next()
             .ok_or(QueryError::InternalErrorNoResponse)?;
-        if let RpcQueryResponse::Variant4 {
-            block_hash,
-            nonce,
-            block_height,
-            permission,
-        } = response
-        {
-            info!(
-                target: QUERY_EXECUTOR_TARGET,
-                "Processed AccessKey response, nonce: {}, permission: {:?}",
-                nonce,
-                permission
-            );
-            Ok(Data {
-                data: AccessKey {
-                    nonce: U64(nonce),
-                    permission: permission
-                        .try_into()
-                        .map_err(|e| QueryError::ConversionError(Box::new(e)))?,
-                },
-                block_height,
-                block_hash: block_hash.into(),
-            })
-        } else {
-            warn!(target: QUERY_EXECUTOR_TARGET, "Unexpected response kind: {:?}", response);
-            Err(QueryError::UnexpectedResponse {
-                expected: "AccessKey",
-                got: query_to_kind(&response),
-            })
-        }
+
+        let ak: RpcViewAccessKeyResponse = serde_json::from_value(response)
+            .map_err(|e| QueryError::DeserializeError(e))?;
+
+        info!(
+            target: QUERY_EXECUTOR_TARGET,
+            "Processed AccessKey response, nonce: {}, permission: {:?}",
+            ak.nonce,
+            ak.permission
+        );
+        Ok(Data {
+            data: AccessKey {
+                nonce: U64(ak.nonce),
+                permission: ak
+                    .permission
+                    .try_into()
+                    .map_err(|e| QueryError::ConversionError(Box::new(e)))?,
+            },
+            block_height: ak.block_height,
+            block_hash: ak
+                .block_hash
+                .try_into()
+                .map_err(|e| QueryError::ConversionError(Box::new(e)))?,
+        })
     }
 }
 
@@ -359,42 +293,36 @@ impl ResponseHandler for AccessKeyHandler {
 pub struct ViewStateHandler;
 
 impl ResponseHandler for ViewStateHandler {
-    type Response = Data<ViewStateResult>;
+    type Response = Data<RpcViewStateResponse>;
     type Query = SimpleQueryRpc;
 
     fn process_response(
         &self,
-        response: Vec<RpcQueryResponse>,
-    ) -> ResultWithMethod<Self::Response, <Self::Query as RpcType>::Error> {
+        response: Vec<serde_json::Value>,
+    ) -> ResultWithMethod<Self::Response> {
         let response = response
             .into_iter()
             .next()
             .ok_or(QueryError::InternalErrorNoResponse)?;
-        if let RpcQueryResponse::Variant2 {
-            proof,
-            values,
-            block_height,
-            block_hash,
-        } = response
-        {
-            info!(
-                target: QUERY_EXECUTOR_TARGET,
-                "Processed ViewState response, values count: {}, proof nodes: {}",
-                values.len(),
-                proof.len()
-            );
-            Ok(Data {
-                data: ViewStateResult { proof, values },
-                block_height,
-                block_hash: block_hash.into(),
-            })
-        } else {
-            warn!(target: QUERY_EXECUTOR_TARGET, "Unexpected response kind: {:?}", response);
-            Err(QueryError::UnexpectedResponse {
-                expected: "ViewState",
-                got: query_to_kind(&response),
-            })
-        }
+
+        let state: RpcViewStateResponse = serde_json::from_value(response)
+            .map_err(|e| QueryError::DeserializeError(e))?;
+
+        info!(
+            target: QUERY_EXECUTOR_TARGET,
+            "Processed ViewState response, values count: {}, proof nodes: {}",
+            state.values.len(),
+            state.proof.len()
+        );
+        Ok(Data {
+            block_height: state.block_height,
+            block_hash: state
+                .block_hash
+                .clone()
+                .try_into()
+                .map_err(|e| QueryError::ConversionError(Box::new(e)))?,
+            data: state,
+        })
     }
 }
 
@@ -402,42 +330,36 @@ impl ResponseHandler for ViewStateHandler {
 pub struct ViewCodeHandler;
 
 impl ResponseHandler for ViewCodeHandler {
-    type Response = Data<ContractCodeView>;
+    type Response = Data<RpcViewCodeResponse>;
     type Query = SimpleQueryRpc;
 
     fn process_response(
         &self,
-        response: Vec<RpcQueryResponse>,
-    ) -> ResultWithMethod<Self::Response, <Self::Query as RpcType>::Error> {
+        response: Vec<serde_json::Value>,
+    ) -> ResultWithMethod<Self::Response> {
         let response = response
             .into_iter()
             .next()
             .ok_or(QueryError::InternalErrorNoResponse)?;
-        if let RpcQueryResponse::Variant1 {
-            code_base64,
-            hash,
-            block_height,
-            block_hash,
-        } = response
-        {
-            info!(
-                target: QUERY_EXECUTOR_TARGET,
-                "Processed ViewCode response, code size: {} bytes, hash: {:?}",
-                code_base64.len(),
-                hash
-            );
-            Ok(Data {
-                data: ContractCodeView { code_base64, hash },
-                block_height,
-                block_hash: block_hash.into(),
-            })
-        } else {
-            warn!(target: QUERY_EXECUTOR_TARGET, "Unexpected response kind: {:?}", response);
-            Err(QueryError::UnexpectedResponse {
-                expected: "ViewCode",
-                got: query_to_kind(&response),
-            })
-        }
+
+        let code: RpcViewCodeResponse = serde_json::from_value(response)
+            .map_err(|e| QueryError::DeserializeError(e))?;
+
+        info!(
+            target: QUERY_EXECUTOR_TARGET,
+            "Processed ViewCode response, code size: {} bytes, hash: {:?}",
+            code.code_base64.len(),
+            code.hash
+        );
+        Ok(Data {
+            block_height: code.block_height,
+            block_hash: code
+                .block_hash
+                .clone()
+                .try_into()
+                .map_err(|e| QueryError::ConversionError(Box::new(e)))?,
+            data: code,
+        })
     }
 }
 
@@ -451,7 +373,7 @@ impl ResponseHandler for RpcValidatorHandler {
     fn process_response(
         &self,
         response: Vec<RpcValidatorResponse>,
-    ) -> ResultWithMethod<Self::Response, <Self::Query as RpcType>::Error> {
+    ) -> ResultWithMethod<Self::Response> {
         let response = response
             .into_iter()
             .next()
@@ -477,7 +399,7 @@ impl ResponseHandler for RpcBlockHandler {
     fn process_response(
         &self,
         response: Vec<RpcBlockResponse>,
-    ) -> ResultWithMethod<Self::Response, <Self::Query as RpcType>::Error> {
+    ) -> ResultWithMethod<Self::Response> {
         let response = response
             .into_iter()
             .next()
@@ -504,7 +426,7 @@ impl<T: RpcType> ResponseHandler for T {
     fn process_response(
         &self,
         response: Vec<<Self::Query as RpcType>::Response>,
-    ) -> ResultWithMethod<Self::Response, <Self::Query as RpcType>::Error> {
+    ) -> ResultWithMethod<Self::Response> {
         let response = response
             .into_iter()
             .next()

--- a/api/src/common/query/handlers/mod.rs
+++ b/api/src/common/query/handlers/mod.rs
@@ -5,8 +5,8 @@ use near_api_types::{
     transaction::result::ExecutionFinalResult,
 };
 use near_openrpc_client::{
-    RpcCallFunctionResponse, RpcViewAccessKeyListResponse,
-    RpcViewAccessKeyResponse, RpcViewAccountResponse, RpcViewCodeResponse, RpcViewStateResponse,
+    RpcCallFunctionResponse, RpcViewAccessKeyListResponse, RpcViewAccessKeyResponse,
+    RpcViewAccountResponse, RpcViewCodeResponse, RpcViewStateResponse,
 };
 use serde::de::DeserializeOwned;
 use std::marker::PhantomData;
@@ -193,7 +193,8 @@ impl ResponseHandler for AccessKeyListHandler {
         &self,
         response: Vec<serde_json::Value>,
     ) -> ResultWithMethod<Self::Response> {
-        let key_list: RpcViewAccessKeyListResponse = serde_json::from_value(take_single(response)?)?;
+        let key_list: RpcViewAccessKeyListResponse =
+            serde_json::from_value(take_single(response)?)?;
 
         info!(
             target: QUERY_EXECUTOR_TARGET,

--- a/api/src/common/query/handlers/mod.rs
+++ b/api/src/common/query/handlers/mod.rs
@@ -21,6 +21,20 @@ use crate::{
 pub mod transformers;
 pub use transformers::*;
 
+fn take_single<T>(responses: Vec<T>) -> Result<T, QueryError> {
+    responses
+        .into_iter()
+        .next()
+        .ok_or(QueryError::InternalErrorNoResponse)
+}
+
+fn convert_block_hash(
+    hash: near_openrpc_client::CryptoHash,
+) -> Result<near_api_types::CryptoHash, QueryError> {
+    hash.try_into()
+        .map_err(|e| QueryError::ConversionError(Box::new(e)))
+}
+
 pub trait ResponseHandler {
     type Response;
     type Query: RpcType;
@@ -55,23 +69,14 @@ where
         &self,
         response: Vec<serde_json::Value>,
     ) -> ResultWithMethod<Self::Response> {
-        let response = response
-            .into_iter()
-            .next()
-            .ok_or(QueryError::InternalErrorNoResponse)?;
-
-        let call_result: RpcCallFunctionResponse = serde_json::from_value(response)
-            .map_err(|e| QueryError::DeserializeError(e))?;
+        let call_result: RpcCallFunctionResponse = serde_json::from_value(take_single(response)?)?;
 
         trace!(target: QUERY_EXECUTOR_TARGET, "Deserializing CallResult, result size: {} bytes", call_result.result.len());
         let data: Response = serde_json::from_slice(&call_result.result)?;
         Ok(Data {
             data,
             block_height: call_result.block_height,
-            block_hash: call_result
-                .block_hash
-                .try_into()
-                .map_err(|e| QueryError::ConversionError(Box::new(e)))?,
+            block_hash: convert_block_hash(call_result.block_hash)?,
         })
     }
 }
@@ -93,22 +98,13 @@ impl ResponseHandler for CallResultRawHandler {
         &self,
         response: Vec<serde_json::Value>,
     ) -> ResultWithMethod<Self::Response> {
-        let response = response
-            .into_iter()
-            .next()
-            .ok_or(QueryError::InternalErrorNoResponse)?;
-
-        let call_result: RpcCallFunctionResponse = serde_json::from_value(response)
-            .map_err(|e| QueryError::DeserializeError(e))?;
+        let call_result: RpcCallFunctionResponse = serde_json::from_value(take_single(response)?)?;
 
         trace!(target: QUERY_EXECUTOR_TARGET, "Returning CallResult raw bytes, result size: {} bytes", call_result.result.len());
         Ok(Data {
             data: call_result.result,
             block_height: call_result.block_height,
-            block_hash: call_result
-                .block_hash
-                .try_into()
-                .map_err(|e| QueryError::ConversionError(Box::new(e)))?,
+            block_hash: convert_block_hash(call_result.block_hash)?,
         })
     }
 }
@@ -133,13 +129,7 @@ where
         &self,
         response: Vec<serde_json::Value>,
     ) -> ResultWithMethod<Self::Response> {
-        let response = response
-            .into_iter()
-            .next()
-            .ok_or(QueryError::InternalErrorNoResponse)?;
-
-        let call_result: RpcCallFunctionResponse = serde_json::from_value(response)
-            .map_err(|e| QueryError::DeserializeError(e))?;
+        let call_result: RpcCallFunctionResponse = serde_json::from_value(take_single(response)?)?;
 
         trace!(target: QUERY_EXECUTOR_TARGET, "Deserializing CallResult using Borsh, result size: {} bytes", call_result.result.len());
         let data: Response = Response::try_from_slice(&call_result.result)
@@ -147,10 +137,7 @@ where
         Ok(Data {
             data,
             block_height: call_result.block_height,
-            block_hash: call_result
-                .block_hash
-                .try_into()
-                .map_err(|e| QueryError::ConversionError(Box::new(e)))?,
+            block_hash: convert_block_hash(call_result.block_hash)?,
         })
     }
 }
@@ -166,13 +153,7 @@ impl ResponseHandler for AccountViewHandler {
         &self,
         response: Vec<serde_json::Value>,
     ) -> ResultWithMethod<Self::Response> {
-        let response = response
-            .into_iter()
-            .next()
-            .ok_or(QueryError::InternalErrorNoResponse)?;
-
-        let account_view: RpcViewAccountResponse = serde_json::from_value(response)
-            .map_err(|e| QueryError::DeserializeError(e))?;
+        let account_view: RpcViewAccountResponse = serde_json::from_value(take_single(response)?)?;
 
         info!(
             target: QUERY_EXECUTOR_TARGET,
@@ -181,11 +162,7 @@ impl ResponseHandler for AccountViewHandler {
         );
 
         let block_height = account_view.block_height;
-        let block_hash = account_view
-            .block_hash
-            .clone()
-            .try_into()
-            .map_err(|e| QueryError::ConversionError(Box::new(e)))?;
+        let block_hash = convert_block_hash(account_view.block_hash.clone())?;
 
         Ok(Data {
             data: Account::try_from(account_view)
@@ -211,13 +188,7 @@ impl ResponseHandler for AccessKeyListHandler {
         &self,
         response: Vec<serde_json::Value>,
     ) -> ResultWithMethod<Self::Response> {
-        let response = response
-            .into_iter()
-            .next()
-            .ok_or(QueryError::InternalErrorNoResponse)?;
-
-        let key_list: RpcViewAccessKeyListResponse = serde_json::from_value(response)
-            .map_err(|e| QueryError::DeserializeError(e))?;
+        let key_list: RpcViewAccessKeyListResponse = serde_json::from_value(take_single(response)?)?;
 
         info!(
             target: QUERY_EXECUTOR_TARGET,
@@ -235,10 +206,7 @@ impl ResponseHandler for AccessKeyListHandler {
                 })
                 .collect(),
             block_height: key_list.block_height,
-            block_hash: key_list
-                .block_hash
-                .try_into()
-                .map_err(|e| QueryError::ConversionError(Box::new(e)))?,
+            block_hash: convert_block_hash(key_list.block_hash)?,
         })
     }
 
@@ -258,13 +226,7 @@ impl ResponseHandler for AccessKeyHandler {
         &self,
         response: Vec<serde_json::Value>,
     ) -> ResultWithMethod<Self::Response> {
-        let response = response
-            .into_iter()
-            .next()
-            .ok_or(QueryError::InternalErrorNoResponse)?;
-
-        let ak: RpcViewAccessKeyResponse = serde_json::from_value(response)
-            .map_err(|e| QueryError::DeserializeError(e))?;
+        let ak: RpcViewAccessKeyResponse = serde_json::from_value(take_single(response)?)?;
 
         info!(
             target: QUERY_EXECUTOR_TARGET,
@@ -281,10 +243,7 @@ impl ResponseHandler for AccessKeyHandler {
                     .map_err(|e| QueryError::ConversionError(Box::new(e)))?,
             },
             block_height: ak.block_height,
-            block_hash: ak
-                .block_hash
-                .try_into()
-                .map_err(|e| QueryError::ConversionError(Box::new(e)))?,
+            block_hash: convert_block_hash(ak.block_hash)?,
         })
     }
 }
@@ -300,13 +259,7 @@ impl ResponseHandler for ViewStateHandler {
         &self,
         response: Vec<serde_json::Value>,
     ) -> ResultWithMethod<Self::Response> {
-        let response = response
-            .into_iter()
-            .next()
-            .ok_or(QueryError::InternalErrorNoResponse)?;
-
-        let state: RpcViewStateResponse = serde_json::from_value(response)
-            .map_err(|e| QueryError::DeserializeError(e))?;
+        let state: RpcViewStateResponse = serde_json::from_value(take_single(response)?)?;
 
         info!(
             target: QUERY_EXECUTOR_TARGET,
@@ -316,11 +269,7 @@ impl ResponseHandler for ViewStateHandler {
         );
         Ok(Data {
             block_height: state.block_height,
-            block_hash: state
-                .block_hash
-                .clone()
-                .try_into()
-                .map_err(|e| QueryError::ConversionError(Box::new(e)))?,
+            block_hash: convert_block_hash(state.block_hash.clone())?,
             data: state,
         })
     }
@@ -337,13 +286,7 @@ impl ResponseHandler for ViewCodeHandler {
         &self,
         response: Vec<serde_json::Value>,
     ) -> ResultWithMethod<Self::Response> {
-        let response = response
-            .into_iter()
-            .next()
-            .ok_or(QueryError::InternalErrorNoResponse)?;
-
-        let code: RpcViewCodeResponse = serde_json::from_value(response)
-            .map_err(|e| QueryError::DeserializeError(e))?;
+        let code: RpcViewCodeResponse = serde_json::from_value(take_single(response)?)?;
 
         info!(
             target: QUERY_EXECUTOR_TARGET,
@@ -353,11 +296,7 @@ impl ResponseHandler for ViewCodeHandler {
         );
         Ok(Data {
             block_height: code.block_height,
-            block_hash: code
-                .block_hash
-                .clone()
-                .try_into()
-                .map_err(|e| QueryError::ConversionError(Box::new(e)))?,
+            block_hash: convert_block_hash(code.block_hash.clone())?,
             data: code,
         })
     }
@@ -374,11 +313,7 @@ impl ResponseHandler for RpcValidatorHandler {
         &self,
         response: Vec<RpcValidatorResponse>,
     ) -> ResultWithMethod<Self::Response> {
-        let response = response
-            .into_iter()
-            .next()
-            .ok_or(QueryError::InternalErrorNoResponse)?;
-
+        let response = take_single(response)?;
         info!(
             target: QUERY_EXECUTOR_TARGET,
             "Processed EpochValidatorInfo response, epoch height: {}, validators count: {}",
@@ -400,11 +335,7 @@ impl ResponseHandler for RpcBlockHandler {
         &self,
         response: Vec<RpcBlockResponse>,
     ) -> ResultWithMethod<Self::Response> {
-        let response = response
-            .into_iter()
-            .next()
-            .ok_or(QueryError::InternalErrorNoResponse)?;
-
+        let response = take_single(response)?;
         info!(
             target: QUERY_EXECUTOR_TARGET,
             "Processed Block response, height: {}, hash: {:?}",
@@ -427,13 +358,8 @@ impl<T: RpcType> ResponseHandler for T {
         &self,
         response: Vec<<Self::Query as RpcType>::Response>,
     ) -> ResultWithMethod<Self::Response> {
-        let response = response
-            .into_iter()
-            .next()
-            .ok_or(QueryError::InternalErrorNoResponse)?;
-
+        let response = take_single(response)?;
         trace!(target: QUERY_EXECUTOR_TARGET, "Processed empty response handler");
-
         Ok(response)
     }
 }

--- a/api/src/common/query/handlers/transformers.rs
+++ b/api/src/common/query/handlers/transformers.rs
@@ -23,7 +23,7 @@ where
     fn process_response(
         &self,
         mut responses: Vec<<H1::Query as RpcType>::Response>,
-    ) -> ResultWithMethod<Self::Response, <H1::Query as RpcType>::Error> {
+    ) -> ResultWithMethod<Self::Response> {
         let (h1, h2) = &self.handlers;
 
         let first_response =
@@ -51,7 +51,7 @@ where
     fn process_response(
         &self,
         mut responses: Vec<<Query as RpcType>::Response>,
-    ) -> ResultWithMethod<Self::Response, <Query as RpcType>::Error> {
+    ) -> ResultWithMethod<Self::Response> {
         let (h1, h2, h3) = &self.handlers;
 
         let first_response =
@@ -107,7 +107,7 @@ where
     fn process_response(
         &self,
         response: Vec<<Self::Query as RpcType>::Response>,
-    ) -> ResultWithMethod<Self::Response, <Self::Query as RpcType>::Error> {
+    ) -> ResultWithMethod<Self::Response> {
         trace!(target: QUERY_EXECUTOR_TARGET, "Processing response with postprocessing, response count: {}", response.len());
         Handler::process_response(&self.handler, response).map(|data| {
             trace!(target: QUERY_EXECUTOR_TARGET, "Applying postprocessing");
@@ -155,7 +155,7 @@ where
     fn process_response(
         &self,
         response: Vec<<Self::Query as RpcType>::Response>,
-    ) -> ResultWithMethod<Self::Response, <Self::Query as RpcType>::Error> {
+    ) -> ResultWithMethod<Self::Response> {
         Handler::process_response(&self.handler, response)
             .map(|data| (self.post_process)(data))?
             .map_err(QueryError::ConversionError)

--- a/api/src/common/query/mod.rs
+++ b/api/src/common/query/mod.rs
@@ -1,13 +1,13 @@
 // TODO: root level doc might be needed here. It's pretty complicated.
 use async_trait::async_trait;
 use futures::future::join_all;
-use near_openapi_client::Client;
 use std::sync::Arc;
 use tracing::{debug, error, info, instrument};
 
 use crate::{
     config::{NetworkConfig, RetryResponse, retry},
     errors::{ArgumentValidationError, QueryError, SendRequestError},
+    rpc_client::RpcClient,
 };
 
 pub mod block_rpc;
@@ -20,19 +20,18 @@ pub use handlers::*;
 
 const QUERY_EXECUTOR_TARGET: &str = "near_api::query::executor";
 
-type ResultWithMethod<T, E> = core::result::Result<T, QueryError<E>>;
+type ResultWithMethod<T> = core::result::Result<T, QueryError>;
 
 #[async_trait]
 pub trait RpcType: Send + Sync + std::fmt::Debug {
     type RpcReference: Send + Sync + Clone;
     type Response;
-    type Error: std::fmt::Debug + Send + Sync;
     async fn send_query(
         &self,
-        client: &Client,
+        client: &RpcClient,
         network: &NetworkConfig,
         reference: &Self::RpcReference,
-    ) -> RetryResponse<Self::Response, SendRequestError<Self::Error>>;
+    ) -> RetryResponse<Self::Response, SendRequestError>;
 }
 
 pub type RequestBuilder<T> = RpcBuilder<<T as ResponseHandler>::Query, T>;
@@ -53,7 +52,6 @@ pub struct MultiRpcBuilder<Query, Handler>
 where
     Query: RpcType,
     Query::Response: std::fmt::Debug + Send + Sync,
-    Query::Error: std::fmt::Debug + Send + Sync,
     Handler: Send + Sync,
 {
     reference: Query::RpcReference,
@@ -64,7 +62,6 @@ where
                 dyn RpcType<
                         Response = Query::Response,
                         RpcReference = Query::RpcReference,
-                        Error = Query::Error,
                     > + Send
                     + Sync,
             >,
@@ -79,7 +76,6 @@ where
     Handler: Default + Send + Sync,
     Query: RpcType,
     Query::Response: std::fmt::Debug + Send + Sync,
-    Query::Error: std::fmt::Debug + Send + Sync,
 {
     pub fn with_reference(reference: impl Into<Query::RpcReference>) -> Self {
         Self {
@@ -95,7 +91,6 @@ where
     Handler: ResponseHandler<Query = Query> + Send + Sync,
     Query: RpcType,
     Query::Response: std::fmt::Debug + Send + Sync,
-    Query::Error: std::fmt::Debug + Send + Sync,
 {
     pub fn new(handler: Handler, reference: impl Into<Query::RpcReference>) -> Self {
         Self {
@@ -191,7 +186,6 @@ where
             dyn RpcType<
                     Response = Query::Response,
                     RpcReference = Query::RpcReference,
-                    Error = Query::Error,
                 > + Send
                 + Sync,
         >,
@@ -222,7 +216,7 @@ where
     pub async fn fetch_from(
         self,
         network: &NetworkConfig,
-    ) -> ResultWithMethod<Handler::Response, Query::Error> {
+    ) -> ResultWithMethod<Handler::Response> {
         let (requests, errors) =
             self.requests
                 .into_iter()
@@ -263,6 +257,7 @@ where
             }
         });
 
+
         let requests: Vec<_> = join_all(requests)
             .await
             .into_iter()
@@ -277,13 +272,13 @@ where
     }
 
     /// Fetch the queries from the default mainnet network configuration.
-    pub async fn fetch_from_mainnet(self) -> ResultWithMethod<Handler::Response, Query::Error> {
+    pub async fn fetch_from_mainnet(self) -> ResultWithMethod<Handler::Response> {
         let network = NetworkConfig::mainnet();
         self.fetch_from(&network).await
     }
 
     /// Fetch the queries from the default testnet network configuration.
-    pub async fn fetch_from_testnet(self) -> ResultWithMethod<Handler::Response, Query::Error> {
+    pub async fn fetch_from_testnet(self) -> ResultWithMethod<Handler::Response> {
         let network = NetworkConfig::testnet();
         self.fetch_from(&network).await
     }
@@ -293,7 +288,6 @@ pub struct RpcBuilder<Query, Handler>
 where
     Query: RpcType,
     Query::Response: std::fmt::Debug + Send + Sync,
-    Query::Error: std::fmt::Debug + Send + Sync,
     Handler: Send + Sync,
 {
     reference: Query::RpcReference,
@@ -303,7 +297,6 @@ where
             dyn RpcType<
                     Response = Query::Response,
                     RpcReference = Query::RpcReference,
-                    Error = Query::Error,
                 > + Send
                 + Sync,
         >,
@@ -317,7 +310,6 @@ where
     Handler: ResponseHandler<Query = Query> + Send + Sync,
     Query: RpcType + 'static,
     Query::Response: std::fmt::Debug + Send + Sync,
-    Query::Error: std::fmt::Debug + Send + Sync,
 {
     pub fn new(
         request: Query,
@@ -414,7 +406,7 @@ where
     pub async fn fetch_from(
         self,
         network: &NetworkConfig,
-    ) -> ResultWithMethod<Handler::Response, Query::Error> {
+    ) -> ResultWithMethod<Handler::Response> {
         let request = self.request?;
 
         debug!(target: QUERY_EXECUTOR_TARGET, "Preparing query");
@@ -440,13 +432,13 @@ where
     }
 
     /// Fetch the query from the default mainnet network configuration.
-    pub async fn fetch_from_mainnet(self) -> ResultWithMethod<Handler::Response, Query::Error> {
+    pub async fn fetch_from_mainnet(self) -> ResultWithMethod<Handler::Response> {
         let network = NetworkConfig::mainnet();
         self.fetch_from(&network).await
     }
 
     /// Fetch the query from the default testnet network configuration.
-    pub async fn fetch_from_testnet(self) -> ResultWithMethod<Handler::Response, Query::Error> {
+    pub async fn fetch_from_testnet(self) -> ResultWithMethod<Handler::Response> {
         let network = NetworkConfig::testnet();
         self.fetch_from(&network).await
     }

--- a/api/src/common/query/mod.rs
+++ b/api/src/common/query/mod.rs
@@ -60,10 +60,8 @@ where
     requests: Vec<
         Result<
             Arc<
-                dyn RpcType<
-                        Response = Query::Response,
-                        RpcReference = Query::RpcReference,
-                    > + Send
+                dyn RpcType<Response = Query::Response, RpcReference = Query::RpcReference>
+                    + Send
                     + Sync,
             >,
             ArgumentValidationError,
@@ -184,10 +182,8 @@ where
     pub fn add_query(
         mut self,
         request: Arc<
-            dyn RpcType<
-                    Response = Query::Response,
-                    RpcReference = Query::RpcReference,
-                > + Send
+            dyn RpcType<Response = Query::Response, RpcReference = Query::RpcReference>
+                + Send
                 + Sync,
         >,
     ) -> Self {
@@ -214,10 +210,7 @@ where
 
     /// Fetch the queries from the provided network.
     #[instrument(skip(self, network), fields(request_count = self.requests.len()))]
-    pub async fn fetch_from(
-        self,
-        network: &NetworkConfig,
-    ) -> ResultWithMethod<Handler::Response> {
+    pub async fn fetch_from(self, network: &NetworkConfig) -> ResultWithMethod<Handler::Response> {
         let (requests, errors) =
             self.requests
                 .into_iter()
@@ -258,7 +251,6 @@ where
             }
         });
 
-
         let requests: Vec<_> = join_all(requests)
             .await
             .into_iter()
@@ -279,9 +271,7 @@ where
     }
 
     /// Fetch the queries from the default mainnet archival network configuration.
-    pub async fn fetch_from_mainnet_archival(
-        self,
-    ) -> ResultWithMethod<Handler::Response> {
+    pub async fn fetch_from_mainnet_archival(self) -> ResultWithMethod<Handler::Response> {
         let network = NetworkConfig::mainnet_archival();
         self.fetch_from(&network).await
     }
@@ -293,9 +283,7 @@ where
     }
 
     /// Fetch the queries from the default testnet archival network configuration.
-    pub async fn fetch_from_testnet_archival(
-        self,
-    ) -> ResultWithMethod<Handler::Response> {
+    pub async fn fetch_from_testnet_archival(self) -> ResultWithMethod<Handler::Response> {
         let network = NetworkConfig::testnet_archival();
         self.fetch_from(&network).await
     }
@@ -311,10 +299,8 @@ where
     #[allow(clippy::type_complexity)]
     request: Result<
         Arc<
-            dyn RpcType<
-                    Response = Query::Response,
-                    RpcReference = Query::RpcReference,
-                > + Send
+            dyn RpcType<Response = Query::Response, RpcReference = Query::RpcReference>
+                + Send
                 + Sync,
         >,
         ArgumentValidationError,
@@ -420,10 +406,7 @@ where
 
     /// Fetch the query from the provided network.
     #[instrument(skip(self, network))]
-    pub async fn fetch_from(
-        self,
-        network: &NetworkConfig,
-    ) -> ResultWithMethod<Handler::Response> {
+    pub async fn fetch_from(self, network: &NetworkConfig) -> ResultWithMethod<Handler::Response> {
         let request = self.request?;
 
         debug!(target: QUERY_EXECUTOR_TARGET, "Preparing query");
@@ -455,9 +438,7 @@ where
     }
 
     /// Fetch the query from the default mainnet archival network configuration.
-    pub async fn fetch_from_mainnet_archival(
-        self,
-    ) -> ResultWithMethod<Handler::Response> {
+    pub async fn fetch_from_mainnet_archival(self) -> ResultWithMethod<Handler::Response> {
         let network = NetworkConfig::mainnet_archival();
         self.fetch_from(&network).await
     }
@@ -469,9 +450,7 @@ where
     }
 
     /// Fetch the query from the default testnet archival network configuration.
-    pub async fn fetch_from_testnet_archival(
-        self,
-    ) -> ResultWithMethod<Handler::Response> {
+    pub async fn fetch_from_testnet_archival(self) -> ResultWithMethod<Handler::Response> {
         let network = NetworkConfig::testnet_archival();
         self.fetch_from(&network).await
     }

--- a/api/src/common/query/query_request.rs
+++ b/api/src/common/query/query_request.rs
@@ -1,15 +1,5 @@
 use near_api_types::{AccountId, CryptoHash, Reference};
-use near_openapi_client::types::{
-    BlockId, CallFunctionByBlockIdRequestType, CallFunctionByFinalityRequestType, Finality,
-    FunctionArgs, PublicKey, RpcQueryRequest, StoreKey, ViewAccessKeyByBlockIdRequestType,
-    ViewAccessKeyByFinalityRequestType, ViewAccessKeyListByBlockIdRequestType,
-    ViewAccessKeyListByFinalityRequestType, ViewAccountByBlockIdRequestType,
-    ViewAccountByFinalityRequestType, ViewCodeByBlockIdRequestType, ViewCodeByFinalityRequestType,
-    ViewGlobalContractCodeByAccountIdByBlockIdRequestType,
-    ViewGlobalContractCodeByAccountIdByFinalityRequestType,
-    ViewGlobalContractCodeByBlockIdRequestType, ViewGlobalContractCodeByFinalityRequestType,
-    ViewStateByBlockIdRequestType, ViewStateByFinalityRequestType,
-};
+use near_openrpc_client::{FunctionArgs, StoreKey};
 use serde::{Deserialize, Serialize};
 
 /// Simplified query request structure that eliminates duplication by removing reference types
@@ -30,7 +20,7 @@ pub enum QueryRequest {
     /// View a specific access key for an account
     ViewAccessKey {
         account_id: AccountId,
-        public_key: PublicKey,
+        public_key: near_openrpc_client::PublicKey,
     },
     /// View all access keys for an account
     ViewAccessKeyList { account_id: AccountId },
@@ -46,272 +36,112 @@ pub enum QueryRequest {
     ViewGlobalContractCodeByAccountId { account_id: AccountId },
 }
 
+fn apply_reference(req: &mut serde_json::Value, reference: &Reference) {
+    match reference {
+        Reference::Final => {
+            req["finality"] = serde_json::Value::String("final".to_string());
+        }
+        Reference::NearFinal => {
+            req["finality"] = serde_json::Value::String("near-final".to_string());
+        }
+        Reference::Optimistic => {
+            req["finality"] = serde_json::Value::String("optimistic".to_string());
+        }
+        Reference::AtBlock(height) => {
+            req["block_id"] = serde_json::json!(*height);
+        }
+        Reference::AtBlockHash(hash) => {
+            req["block_id"] = serde_json::Value::String(hash.to_string());
+        }
+    }
+}
+
 impl QueryRequest {
-    /// Convert this simplified query request to the OpenAPI RpcQueryRequest enum
-    /// This method handles the conversion from our unified Reference type to the appropriate
-    /// OpenAPI variant based on the reference type
-    pub fn to_rpc_query_request(
-        self,
-        reference: Reference,
-    ) -> near_openapi_client::types::RpcQueryRequest {
+    /// Convert this simplified query request to a JSON value suitable for the "query" RPC method.
+    pub fn to_rpc_query_request(self, reference: Reference) -> serde_json::Value {
         match self {
             Self::ViewAccount { account_id } => {
-                match reference {
-                    Reference::Final => RpcQueryRequest::ViewAccountByFinality {
-                        account_id,
-                        finality: Finality::Final,
-                        request_type: ViewAccountByFinalityRequestType::ViewAccount,
-                    },
-                    Reference::NearFinal => RpcQueryRequest::ViewAccountByFinality {
-                        account_id,
-                        finality: Finality::NearFinal,
-                        request_type: ViewAccountByFinalityRequestType::ViewAccount,
-                    },
-                    Reference::Optimistic => RpcQueryRequest::ViewAccountByFinality {
-                        account_id,
-                        finality: Finality::Optimistic,
-                        request_type: ViewAccountByFinalityRequestType::ViewAccount,
-                    },
-                    Reference::AtBlock(height) => RpcQueryRequest::ViewAccountByBlockId {
-                        account_id,
-                        block_id: BlockId::BlockHeight(height),
-                        request_type: ViewAccountByBlockIdRequestType::ViewAccount,
-                    },
-                    Reference::AtBlockHash(hash) => RpcQueryRequest::ViewAccountByBlockId {
-                        account_id,
-                        block_id: BlockId::CryptoHash(hash.into()),
-                        request_type: ViewAccountByBlockIdRequestType::ViewAccount,
-                    },
-                }
-            },
+                let mut req = serde_json::json!({
+                    "request_type": "view_account",
+                    "account_id": account_id,
+                });
+                apply_reference(&mut req, &reference);
+                req
+            }
             Self::ViewCode { account_id } => {
-                match reference {
-                    Reference::Final => RpcQueryRequest::ViewCodeByFinality {
-                        account_id,
-                        finality: Finality::Final,
-                        request_type: ViewCodeByFinalityRequestType::ViewCode,
-                    },
-                    Reference::NearFinal => RpcQueryRequest::ViewCodeByFinality {
-                        account_id,
-                        finality: Finality::NearFinal,
-                        request_type: ViewCodeByFinalityRequestType::ViewCode,
-                    },
-                    Reference::Optimistic => RpcQueryRequest::ViewCodeByFinality {
-                        account_id,
-                        finality: Finality::Optimistic,
-                        request_type: ViewCodeByFinalityRequestType::ViewCode,
-                    },
-                    Reference::AtBlock(height) => RpcQueryRequest::ViewCodeByBlockId {
-                        account_id,
-                        block_id: BlockId::BlockHeight(height),
-                        request_type: ViewCodeByBlockIdRequestType::ViewCode,
-                    },
-                    Reference::AtBlockHash(hash) => RpcQueryRequest::ViewCodeByBlockId {
-                        account_id,
-                        block_id: BlockId::CryptoHash(hash.into()),
-                        request_type: ViewCodeByBlockIdRequestType::ViewCode,
-                    },
+                let mut req = serde_json::json!({
+                    "request_type": "view_code",
+                    "account_id": account_id,
+                });
+                apply_reference(&mut req, &reference);
+                req
+            }
+            Self::ViewState {
+                account_id,
+                include_proof,
+                prefix_base64,
+            } => {
+                let mut req = serde_json::json!({
+                    "request_type": "view_state",
+                    "account_id": account_id,
+                    "prefix_base64": prefix_base64,
+                });
+                if let Some(include_proof) = include_proof {
+                    req["include_proof"] = serde_json::json!(include_proof);
                 }
-            },
-            Self::ViewState { account_id, include_proof, prefix_base64 } => {
-                match reference {
-                    Reference::Final => RpcQueryRequest::ViewStateByFinality {
-                        account_id,
-                        finality: Finality::Final,
-                        include_proof,
-                        prefix_base64,
-                        request_type: ViewStateByFinalityRequestType::ViewState,
-                    },
-                    Reference::NearFinal => RpcQueryRequest::ViewStateByFinality {
-                        account_id,
-                        finality: Finality::NearFinal,
-                        include_proof,
-                        prefix_base64,
-                        request_type: ViewStateByFinalityRequestType::ViewState,
-                    },
-                    Reference::Optimistic => RpcQueryRequest::ViewStateByFinality {
-                        account_id,
-                        finality: Finality::Optimistic,
-                        include_proof,
-                        prefix_base64,
-                        request_type: ViewStateByFinalityRequestType::ViewState,
-                    },
-                    Reference::AtBlock(height) => RpcQueryRequest::ViewStateByBlockId {
-                        account_id,
-                        block_id: BlockId::BlockHeight(height),
-                        include_proof,
-                        prefix_base64,
-                        request_type: ViewStateByBlockIdRequestType::ViewState,
-                    },
-                    Reference::AtBlockHash(hash) => RpcQueryRequest::ViewStateByBlockId {
-                        account_id,
-                        block_id: BlockId::CryptoHash(hash.into()),
-                        include_proof,
-                        prefix_base64,
-                        request_type: ViewStateByBlockIdRequestType::ViewState,
-                    },
-                }
-            },
-            Self::ViewAccessKey { account_id, public_key } => {
-                match reference {
-                    Reference::Final => RpcQueryRequest::ViewAccessKeyByFinality {
-                        account_id,
-                        public_key,
-                        finality: Finality::Final,
-                        request_type: ViewAccessKeyByFinalityRequestType::ViewAccessKey,
-                    },
-                    Reference::Optimistic => RpcQueryRequest::ViewAccessKeyByFinality {
-                        account_id,
-                        public_key,
-                        finality: Finality::Optimistic,
-                        request_type: ViewAccessKeyByFinalityRequestType::ViewAccessKey,
-                    },
-                    Reference::NearFinal => RpcQueryRequest::ViewAccessKeyByFinality {
-                        account_id,
-                        public_key,
-                        finality: Finality::NearFinal,
-                        request_type: ViewAccessKeyByFinalityRequestType::ViewAccessKey,
-                    },
-                    Reference::AtBlock(height) => RpcQueryRequest::ViewAccessKeyByBlockId {
-                        account_id,
-                        public_key,
-                        block_id: BlockId::BlockHeight(height),
-                        request_type: ViewAccessKeyByBlockIdRequestType::ViewAccessKey,
-                    },
-                    Reference::AtBlockHash(hash) => RpcQueryRequest::ViewAccessKeyByBlockId {
-                        account_id,
-                        public_key,
-                        block_id: BlockId::CryptoHash(hash.into()),
-                        request_type: ViewAccessKeyByBlockIdRequestType::ViewAccessKey,
-                    },
-                }
-            },
+                apply_reference(&mut req, &reference);
+                req
+            }
+            Self::ViewAccessKey {
+                account_id,
+                public_key,
+            } => {
+                let mut req = serde_json::json!({
+                    "request_type": "view_access_key",
+                    "account_id": account_id,
+                    "public_key": public_key,
+                });
+                apply_reference(&mut req, &reference);
+                req
+            }
             Self::ViewAccessKeyList { account_id } => {
-                match reference {
-                    Reference::Final => RpcQueryRequest::ViewAccessKeyListByFinality {
-                        account_id,
-                        finality: Finality::Final,
-                        request_type: ViewAccessKeyListByFinalityRequestType::ViewAccessKeyList,
-                    },
-                    Reference::Optimistic => RpcQueryRequest::ViewAccessKeyListByFinality {
-                        account_id,
-                        finality: Finality::Optimistic,
-                        request_type: ViewAccessKeyListByFinalityRequestType::ViewAccessKeyList,
-                    },
-                    Reference::NearFinal => RpcQueryRequest::ViewAccessKeyListByFinality {
-                        account_id,
-                        finality: Finality::NearFinal,
-                        request_type: ViewAccessKeyListByFinalityRequestType::ViewAccessKeyList,
-                    },
-                    Reference::AtBlock(height) => RpcQueryRequest::ViewAccessKeyListByBlockId {
-                        account_id,
-                        block_id: BlockId::BlockHeight(height),
-                        request_type: ViewAccessKeyListByBlockIdRequestType::ViewAccessKeyList,
-                    },
-                    Reference::AtBlockHash(hash) => RpcQueryRequest::ViewAccessKeyListByBlockId {
-                        account_id,
-                        block_id: BlockId::CryptoHash(hash.into()),
-                        request_type: ViewAccessKeyListByBlockIdRequestType::ViewAccessKeyList,
-                    },
-                }
-            },
-            Self::CallFunction { account_id, method_name, args_base64 } => {
-                match reference {
-                    Reference::Final => RpcQueryRequest::CallFunctionByFinality {
-                        account_id,
-                        method_name,
-                        args_base64,
-                        finality: Finality::Final,
-                        request_type: CallFunctionByFinalityRequestType::CallFunction,
-                    },
-                    Reference::Optimistic => RpcQueryRequest::CallFunctionByFinality {
-                        account_id,
-                        method_name,
-                        args_base64,
-                        finality: Finality::Optimistic,
-                        request_type: CallFunctionByFinalityRequestType::CallFunction,
-                    },
-                    Reference::NearFinal => RpcQueryRequest::CallFunctionByFinality {
-                        account_id,
-                        method_name,
-                        args_base64,
-                        finality: Finality::NearFinal,
-                        request_type: CallFunctionByFinalityRequestType::CallFunction,
-                    },
-                    Reference::AtBlock(height) => RpcQueryRequest::CallFunctionByBlockId {
-                        account_id,
-                        method_name,
-                        args_base64,
-                        block_id: BlockId::BlockHeight(height),
-                        request_type: CallFunctionByBlockIdRequestType::CallFunction,
-                    },
-                    Reference::AtBlockHash(hash) => RpcQueryRequest::CallFunctionByBlockId {
-                        account_id,
-                        method_name,
-                        args_base64,
-                        block_id: BlockId::CryptoHash(hash.into()),
-                        request_type: CallFunctionByBlockIdRequestType::CallFunction,
-                    },
-                }
-            },
+                let mut req = serde_json::json!({
+                    "request_type": "view_access_key_list",
+                    "account_id": account_id,
+                });
+                apply_reference(&mut req, &reference);
+                req
+            }
+            Self::CallFunction {
+                account_id,
+                method_name,
+                args_base64,
+            } => {
+                let mut req = serde_json::json!({
+                    "request_type": "call_function",
+                    "account_id": account_id,
+                    "method_name": method_name,
+                    "args_base64": args_base64,
+                });
+                apply_reference(&mut req, &reference);
+                req
+            }
             Self::ViewGlobalContractCode { code_hash } => {
-                match reference {
-                    Reference::Final => RpcQueryRequest::ViewGlobalContractCodeByFinality {
-                        code_hash: code_hash.into(),
-                        finality: Finality::Final,
-                        request_type: ViewGlobalContractCodeByFinalityRequestType::ViewGlobalContractCode,
-                    },
-                    Reference::Optimistic => RpcQueryRequest::ViewGlobalContractCodeByFinality {
-                        code_hash: code_hash.into(),
-                        finality: Finality::Optimistic,
-                        request_type: ViewGlobalContractCodeByFinalityRequestType::ViewGlobalContractCode,
-                    },
-                    Reference::NearFinal => RpcQueryRequest::ViewGlobalContractCodeByFinality {
-                        code_hash: code_hash.into(),
-                        finality: Finality::NearFinal,
-                        request_type: ViewGlobalContractCodeByFinalityRequestType::ViewGlobalContractCode,
-                    },
-                    Reference::AtBlock(height) => RpcQueryRequest::ViewGlobalContractCodeByBlockId {
-                        code_hash: code_hash.into(),
-                        block_id: BlockId::BlockHeight(height),
-                        request_type: ViewGlobalContractCodeByBlockIdRequestType::ViewGlobalContractCode,
-                    },
-                    Reference::AtBlockHash(hash) => RpcQueryRequest::ViewGlobalContractCodeByBlockId {
-                        code_hash: code_hash.into(),
-                        block_id: BlockId::CryptoHash(hash.into()),
-                        request_type: ViewGlobalContractCodeByBlockIdRequestType::ViewGlobalContractCode,
-                    },
-                }
-            },
+                let mut req = serde_json::json!({
+                    "request_type": "view_global_contract_code",
+                    "code_hash": code_hash.to_string(),
+                });
+                apply_reference(&mut req, &reference);
+                req
+            }
             Self::ViewGlobalContractCodeByAccountId { account_id } => {
-                match reference {
-                    Reference::Final => RpcQueryRequest::ViewGlobalContractCodeByAccountIdByFinality {
-                        account_id,
-                        finality: Finality::Final,
-                        request_type: ViewGlobalContractCodeByAccountIdByFinalityRequestType::ViewGlobalContractCodeByAccountId,
-                    },
-                    Reference::Optimistic => RpcQueryRequest::ViewGlobalContractCodeByAccountIdByFinality {
-                        account_id,
-                        finality: Finality::Optimistic,
-                        request_type: ViewGlobalContractCodeByAccountIdByFinalityRequestType::ViewGlobalContractCodeByAccountId,
-                    },
-                    Reference::NearFinal => RpcQueryRequest::ViewGlobalContractCodeByAccountIdByFinality {
-                        account_id,
-                        finality: Finality::NearFinal,
-                        request_type: ViewGlobalContractCodeByAccountIdByFinalityRequestType::ViewGlobalContractCodeByAccountId,
-                    },
-                    Reference::AtBlock(height) => RpcQueryRequest::ViewGlobalContractCodeByAccountIdByBlockId {
-                        account_id,
-                        block_id: BlockId::BlockHeight(height),
-                        request_type: ViewGlobalContractCodeByAccountIdByBlockIdRequestType::ViewGlobalContractCodeByAccountId,
-                    },
-                    Reference::AtBlockHash(hash) => RpcQueryRequest::ViewGlobalContractCodeByAccountIdByBlockId {
-                        account_id,
-                        block_id: BlockId::CryptoHash(hash.into()),
-                        request_type: ViewGlobalContractCodeByAccountIdByBlockIdRequestType::ViewGlobalContractCodeByAccountId,
-                    },
-                }
-            },
+                let mut req = serde_json::json!({
+                    "request_type": "view_global_contract_code_by_account_id",
+                    "account_id": account_id,
+                });
+                apply_reference(&mut req, &reference);
+                req
+            }
         }
     }
 }

--- a/api/src/common/query/query_rpc.rs
+++ b/api/src/common/query/query_rpc.rs
@@ -1,8 +1,4 @@
 use async_trait::async_trait;
-use near_openapi_client::types::{
-    ErrorWrapperForRpcQueryError, JsonRpcRequestForQuery, JsonRpcRequestForQueryMethod,
-    JsonRpcResponseForRpcQueryResponseAndRpcQueryError, RpcQueryError, RpcQueryResponse,
-};
 
 use crate::{
     NetworkConfig,
@@ -10,6 +6,7 @@ use crate::{
     common::utils::{is_critical_query_error, to_retry_error},
     config::RetryResponse,
     errors::SendRequestError,
+    rpc_client::{RpcCallError, RpcClient, RpcError, RpcErrorCause},
 };
 use near_api_types::Reference;
 
@@ -21,50 +18,50 @@ pub struct SimpleQueryRpc {
 #[async_trait]
 impl RpcType for SimpleQueryRpc {
     type RpcReference = Reference;
-    type Response = RpcQueryResponse;
-    type Error = RpcQueryError;
+    type Response = serde_json::Value;
     async fn send_query(
         &self,
-        client: &near_openapi_client::Client,
+        client: &RpcClient,
         _network: &NetworkConfig,
         reference: &Reference,
-    ) -> RetryResponse<RpcQueryResponse, SendRequestError<RpcQueryError>> {
+    ) -> RetryResponse<serde_json::Value, SendRequestError> {
         let request = self.request.clone().to_rpc_query_request(reference.clone());
-        let response = client
-            .query(&JsonRpcRequestForQuery {
-                id: "0".to_string(),
-                jsonrpc: "2.0".to_string(),
-                method: JsonRpcRequestForQueryMethod::Query,
-                params: request,
-            })
-            .await
-            .map(|r| r.into_inner())
-            .map_err(SendRequestError::from);
+        match client.call::<_, serde_json::Value>("query", request).await {
+            Ok(value) => {
+                // NEAR's query method returns a successful JSON-RPC response even for
+                // WASM execution errors. The error is embedded as an "error" string field
+                // in the result body (e.g., {"error": "wasm execution failed...", "logs": []}).
+                // We need to detect this and convert it to a proper RPC error.
+                if let Some(error_msg) = value.get("error").and_then(|e| e.as_str()) {
+                    let cause_name = if error_msg.contains("CodeDoesNotExist") {
+                        "CONTRACT_EXECUTION_ERROR"
+                    } else if error_msg.contains("MethodNotFound")
+                        || error_msg.contains("MethodResolveError")
+                    {
+                        "CONTRACT_EXECUTION_ERROR"
+                    } else {
+                        "CONTRACT_EXECUTION_ERROR"
+                    };
 
-        match response {
-            Ok(JsonRpcResponseForRpcQueryResponseAndRpcQueryError::Variant0 { result, .. }) => {
-                RetryResponse::Ok(result)
+                    let err = SendRequestError::from(RpcCallError::Rpc(RpcError {
+                        code: -32000,
+                        message: "Server error".to_string(),
+                        data: Some(serde_json::Value::String(error_msg.to_string())),
+                        name: Some("HANDLER_ERROR".to_string()),
+                        cause: Some(RpcErrorCause {
+                            name: cause_name.to_string(),
+                            info: Some(serde_json::json!({
+                                "error_message": error_msg,
+                            })),
+                        }),
+                    }));
+                    return to_retry_error(err, is_critical_query_error);
+                }
+                RetryResponse::Ok(value)
             }
-            Ok(JsonRpcResponseForRpcQueryResponseAndRpcQueryError::Variant1 { error, .. }) => {
-                let error = SendRequestError::from(error);
-                to_retry_error(error, is_critical_query_error)
-            }
-            Err(err) => to_retry_error(err, is_critical_query_error),
-        }
-    }
-}
-
-impl From<ErrorWrapperForRpcQueryError> for SendRequestError<RpcQueryError> {
-    fn from(err: ErrorWrapperForRpcQueryError) -> Self {
-        match err {
-            ErrorWrapperForRpcQueryError::InternalError(internal_error) => {
-                Self::InternalError(internal_error)
-            }
-            ErrorWrapperForRpcQueryError::RequestValidationError(
-                rpc_request_validation_error_kind,
-            ) => Self::RequestValidationError(rpc_request_validation_error_kind),
-            ErrorWrapperForRpcQueryError::HandlerError(server_error) => {
-                Self::ServerError(server_error)
+            Err(err) => {
+                let err = SendRequestError::from(err);
+                to_retry_error(err, is_critical_query_error)
             }
         }
     }

--- a/api/src/common/query/query_rpc.rs
+++ b/api/src/common/query/query_rpc.rs
@@ -1,18 +1,39 @@
 use async_trait::async_trait;
 
+use near_openrpc_client::{RpcError, RpcErrorCause};
+
 use crate::{
     NetworkConfig,
     advanced::{RpcType, query_request::QueryRequest},
     common::utils::{is_critical_query_error, to_retry_error},
     config::RetryResponse,
     errors::SendRequestError,
-    rpc_client::{RpcCallError, RpcClient, RpcError, RpcErrorCause},
+    rpc_client::{RpcCallError, RpcClient},
 };
 use near_api_types::Reference;
 
 #[derive(Clone, Debug)]
 pub struct SimpleQueryRpc {
     pub request: QueryRequest,
+}
+
+/// Synthesize a `SendRequestError` for query-embedded execution errors.
+///
+/// NEAR's query RPC returns HTTP 200 with an `"error"` string field in the
+/// result body for WASM execution failures. We convert this into a proper
+/// `RpcError` with a `CONTRACT_EXECUTION_ERROR` cause so the retry logic
+/// and typed error matching work uniformly.
+fn query_execution_error(error_msg: &str) -> SendRequestError {
+    SendRequestError::from(RpcCallError::Rpc(RpcError {
+        code: -32000,
+        message: "Server error".to_string(),
+        data: Some(serde_json::Value::String(error_msg.to_string())),
+        name: Some("HANDLER_ERROR".to_string()),
+        cause: Some(RpcErrorCause {
+            name: "CONTRACT_EXECUTION_ERROR".to_string(),
+            info: Some(serde_json::json!({ "error_message": error_msg })),
+        }),
+    }))
 }
 
 #[async_trait]
@@ -28,41 +49,15 @@ impl RpcType for SimpleQueryRpc {
         let request = self.request.clone().to_rpc_query_request(reference.clone());
         match client.call::<_, serde_json::Value>("query", request).await {
             Ok(value) => {
-                // NEAR's query method returns a successful JSON-RPC response even for
-                // WASM execution errors. The error is embedded as an "error" string field
-                // in the result body (e.g., {"error": "wasm execution failed...", "logs": []}).
-                // We need to detect this and convert it to a proper RPC error.
                 if let Some(error_msg) = value.get("error").and_then(|e| e.as_str()) {
-                    let cause_name = if error_msg.contains("CodeDoesNotExist") {
-                        "CONTRACT_EXECUTION_ERROR"
-                    } else if error_msg.contains("MethodNotFound")
-                        || error_msg.contains("MethodResolveError")
-                    {
-                        "CONTRACT_EXECUTION_ERROR"
-                    } else {
-                        "CONTRACT_EXECUTION_ERROR"
-                    };
-
-                    let err = SendRequestError::from(RpcCallError::Rpc(RpcError {
-                        code: -32000,
-                        message: "Server error".to_string(),
-                        data: Some(serde_json::Value::String(error_msg.to_string())),
-                        name: Some("HANDLER_ERROR".to_string()),
-                        cause: Some(RpcErrorCause {
-                            name: cause_name.to_string(),
-                            info: Some(serde_json::json!({
-                                "error_message": error_msg,
-                            })),
-                        }),
-                    }));
-                    return to_retry_error(err, is_critical_query_error);
+                    return to_retry_error(
+                        query_execution_error(error_msg),
+                        is_critical_query_error,
+                    );
                 }
                 RetryResponse::Ok(value)
             }
-            Err(err) => {
-                let err = SendRequestError::from(err);
-                to_retry_error(err, is_critical_query_error)
-            }
+            Err(err) => to_retry_error(SendRequestError::from(err), is_critical_query_error),
         }
     }
 }

--- a/api/src/common/query/query_rpc.rs
+++ b/api/src/common/query/query_rpc.rs
@@ -1,39 +1,18 @@
 use async_trait::async_trait;
 
-use near_openrpc_client::{RpcError, RpcErrorCause};
-
 use crate::{
     NetworkConfig,
     advanced::{RpcType, query_request::QueryRequest},
     common::utils::{is_critical_query_error, to_retry_error},
     config::RetryResponse,
     errors::SendRequestError,
-    rpc_client::{RpcCallError, RpcClient},
+    rpc_client::RpcClient,
 };
 use near_api_types::Reference;
 
 #[derive(Clone, Debug)]
 pub struct SimpleQueryRpc {
     pub request: QueryRequest,
-}
-
-/// Synthesize a `SendRequestError` for query-embedded execution errors.
-///
-/// NEAR's query RPC returns HTTP 200 with an `"error"` string field in the
-/// result body for WASM execution failures. We convert this into a proper
-/// `RpcError` with a `CONTRACT_EXECUTION_ERROR` cause so the retry logic
-/// and typed error matching work uniformly.
-fn query_execution_error(error_msg: &str) -> SendRequestError {
-    SendRequestError::from(RpcCallError::Rpc(RpcError {
-        code: -32000,
-        message: "Server error".to_string(),
-        data: Some(serde_json::Value::String(error_msg.to_string())),
-        name: Some("HANDLER_ERROR".to_string()),
-        cause: Some(RpcErrorCause {
-            name: "CONTRACT_EXECUTION_ERROR".to_string(),
-            info: Some(serde_json::json!({ "error_message": error_msg })),
-        }),
-    }))
 }
 
 #[async_trait]
@@ -51,7 +30,7 @@ impl RpcType for SimpleQueryRpc {
             Ok(value) => {
                 if let Some(error_msg) = value.get("error").and_then(|e| e.as_str()) {
                     return to_retry_error(
-                        query_execution_error(error_msg),
+                        SendRequestError::ContractExecutionError(error_msg.to_string()),
                         is_critical_query_error,
                     );
                 }

--- a/api/src/common/query/tx_rpc.rs
+++ b/api/src/common/query/tx_rpc.rs
@@ -45,16 +45,22 @@ impl RpcType for TransactionStatusRpc {
         reference: &TransactionStatusRef,
     ) -> RetryResponse<Self::Response, SendRequestError> {
         let request = RpcTransactionStatusRequest::TxHashSenderAccountId {
-            sender_account_id: near_openrpc_client::AccountId(reference.sender_account_id.to_string()),
+            sender_account_id: near_openrpc_client::AccountId(
+                reference.sender_account_id.to_string(),
+            ),
             tx_hash: reference.tx_hash.into(),
             wait_until: reference.wait_until,
         };
 
-        match client.call::<_, RpcTransactionResponse>("tx", request).await {
+        match client
+            .call::<_, RpcTransactionResponse>("tx", request)
+            .await
+        {
             Ok(response) => RetryResponse::Ok(response),
-            Err(err) => {
-                to_retry_error(SendRequestError::from(err), is_critical_transaction_status_error)
-            }
+            Err(err) => to_retry_error(
+                SendRequestError::from(err),
+                is_critical_transaction_status_error,
+            ),
         }
     }
 }
@@ -137,12 +143,10 @@ impl RpcType for TransactionProofRpc {
             .await
         {
             Ok(response) => RetryResponse::Ok(response),
-            Err(err) => {
-                to_retry_error(
-                    SendRequestError::from(err),
-                    is_critical_light_client_proof_error,
-                )
-            }
+            Err(err) => to_retry_error(
+                SendRequestError::from(err),
+                is_critical_light_client_proof_error,
+            ),
         }
     }
 }

--- a/api/src/common/query/validator_rpc.rs
+++ b/api/src/common/query/validator_rpc.rs
@@ -4,7 +4,7 @@ use near_openrpc_client::{BlockId, EpochId, RpcValidatorRequest, RpcValidatorRes
 use crate::common::utils::to_retry_error;
 use crate::errors::SendRequestError;
 use crate::{
-    NetworkConfig, advanced::RpcType, common::utils::is_critical_validator_error,
+    NetworkConfig, advanced::RpcType, common::utils::is_critical_rpc_error,
     config::RetryResponse, rpc_client::RpcClient,
 };
 
@@ -40,7 +40,7 @@ impl RpcType for SimpleValidatorRpc {
             Ok(response) => RetryResponse::Ok(response),
             Err(err) => {
                 let err = SendRequestError::from(err);
-                to_retry_error(err, is_critical_validator_error)
+                to_retry_error(err, is_critical_rpc_error)
             }
         }
     }

--- a/api/src/common/query/validator_rpc.rs
+++ b/api/src/common/query/validator_rpc.rs
@@ -1,16 +1,11 @@
 use near_api_types::EpochReference;
-use near_openapi_client::Client;
-use near_openapi_client::types::{
-    BlockId, EpochId, ErrorWrapperForRpcValidatorError, JsonRpcRequestForValidators,
-    JsonRpcRequestForValidatorsMethod, JsonRpcResponseForRpcValidatorResponseAndRpcValidatorError,
-    RpcValidatorError, RpcValidatorRequest, RpcValidatorResponse,
-};
+use near_openrpc_client::{BlockId, EpochId, RpcValidatorRequest, RpcValidatorResponse};
 
 use crate::common::utils::to_retry_error;
 use crate::errors::SendRequestError;
 use crate::{
     NetworkConfig, advanced::RpcType, common::utils::is_critical_validator_error,
-    config::RetryResponse,
+    config::RetryResponse, rpc_client::RpcClient,
 };
 
 #[derive(Clone, Debug)]
@@ -20,13 +15,12 @@ pub struct SimpleValidatorRpc;
 impl RpcType for SimpleValidatorRpc {
     type RpcReference = EpochReference;
     type Response = RpcValidatorResponse;
-    type Error = RpcValidatorError;
     async fn send_query(
         &self,
-        client: &Client,
+        client: &RpcClient,
         _network: &NetworkConfig,
         reference: &EpochReference,
-    ) -> RetryResponse<RpcValidatorResponse, SendRequestError<RpcValidatorError>> {
+    ) -> RetryResponse<RpcValidatorResponse, SendRequestError> {
         let request = match reference {
             EpochReference::Latest => RpcValidatorRequest::Latest,
             EpochReference::AtEpoch(epoch) => {
@@ -39,45 +33,14 @@ impl RpcType for SimpleValidatorRpc {
                 RpcValidatorRequest::BlockId(BlockId::CryptoHash((*block_hash).into()))
             }
         };
-        let response = client
-            .validators(&JsonRpcRequestForValidators {
-                id: "0".to_string(),
-                jsonrpc: "2.0".to_string(),
-                method: JsonRpcRequestForValidatorsMethod::Validators,
-                params: request,
-            })
+        match client
+            .call::<_, RpcValidatorResponse>("validators", request)
             .await
-            .map(|r| r.into_inner())
-            .map_err(SendRequestError::from);
-
-        match response {
-            Ok(JsonRpcResponseForRpcValidatorResponseAndRpcValidatorError::Variant0 {
-                result,
-                ..
-            }) => RetryResponse::Ok(result),
-            Ok(JsonRpcResponseForRpcValidatorResponseAndRpcValidatorError::Variant1 {
-                error,
-                ..
-            }) => {
-                let error: SendRequestError<RpcValidatorError> = SendRequestError::from(error);
-                to_retry_error(error, is_critical_validator_error)
-            }
-            Err(err) => to_retry_error(err, is_critical_validator_error),
-        }
-    }
-}
-
-impl From<ErrorWrapperForRpcValidatorError> for SendRequestError<RpcValidatorError> {
-    fn from(err: ErrorWrapperForRpcValidatorError) -> Self {
-        match err {
-            ErrorWrapperForRpcValidatorError::InternalError(internal_error) => {
-                Self::InternalError(internal_error)
-            }
-            ErrorWrapperForRpcValidatorError::RequestValidationError(
-                rpc_request_validation_error_kind,
-            ) => Self::RequestValidationError(rpc_request_validation_error_kind),
-            ErrorWrapperForRpcValidatorError::HandlerError(server_error) => {
-                Self::ServerError(server_error)
+        {
+            Ok(response) => RetryResponse::Ok(response),
+            Err(err) => {
+                let err = SendRequestError::from(err);
+                to_retry_error(err, is_critical_validator_error)
             }
         }
     }

--- a/api/src/common/query/validator_rpc.rs
+++ b/api/src/common/query/validator_rpc.rs
@@ -4,8 +4,8 @@ use near_openrpc_client::{BlockId, EpochId, RpcValidatorRequest, RpcValidatorRes
 use crate::common::utils::to_retry_error;
 use crate::errors::SendRequestError;
 use crate::{
-    NetworkConfig, advanced::RpcType, common::utils::is_critical_rpc_error,
-    config::RetryResponse, rpc_client::RpcClient,
+    NetworkConfig, advanced::RpcType, common::utils::is_critical_rpc_error, config::RetryResponse,
+    rpc_client::RpcClient,
 };
 
 #[derive(Clone, Debug)]

--- a/api/src/common/send.rs
+++ b/api/src/common/send.rs
@@ -299,9 +299,7 @@ impl ExecuteSignedTransaction {
                     Ok(rpc_response) => match rpc_response {
                         RpcTransactionResponse::Empty {
                             final_execution_status,
-                        } => RetryResponse::Ok(SendImplResponse::Pending(
-                            final_execution_status,
-                        )),
+                        } => RetryResponse::Ok(SendImplResponse::Pending(final_execution_status)),
                         RpcTransactionResponse::FinalExecutionOutcomeView {
                             final_execution_status: _,
                             receipts_outcome,
@@ -606,7 +604,9 @@ pub fn to_final_execution_outcome(response: RpcTransactionResponse) -> FinalExec
             transaction_outcome,
         },
         RpcTransactionResponse::Empty { .. } => {
-            unreachable!("Empty response should be handled before calling to_final_execution_outcome")
+            unreachable!(
+                "Empty response should be handled before calling to_final_execution_outcome"
+            )
         }
     }
 }

--- a/api/src/common/send.rs
+++ b/api/src/common/send.rs
@@ -308,15 +308,8 @@ impl ExecuteSignedTransaction {
                             status,
                             transaction,
                             transaction_outcome,
-                        } => RetryResponse::Ok(SendImplResponse::Full(Box::new(
-                            FinalExecutionOutcomeView {
-                                receipts_outcome,
-                                status,
-                                transaction,
-                                transaction_outcome,
-                            },
-                        ))),
-                        RpcTransactionResponse::FinalExecutionOutcomeWithReceiptView {
+                        }
+                        | RpcTransactionResponse::FinalExecutionOutcomeWithReceiptView {
                             final_execution_status: _,
                             receipts: _,
                             receipts_outcome,

--- a/api/src/common/send.rs
+++ b/api/src/common/send.rs
@@ -1,14 +1,13 @@
 use std::fmt;
 use std::sync::Arc;
 
-use near_openapi_client::types::{
-    ErrorWrapperForRpcTransactionError, FinalExecutionOutcomeView, JsonRpcRequestForSendTx,
-    JsonRpcResponseForRpcTransactionResponseAndRpcTransactionError, RpcSendTransactionRequest,
-    RpcTransactionError, RpcTransactionResponse,
+use near_openrpc_client::{
+    FinalExecutionOutcomeView, RpcSendTransactionRequest, RpcTransactionResponse,
+    SignedTransaction as OpenRpcSignedTransaction, TxExecutionStatus,
 };
 
 use near_api_types::{
-    BlockHeight, CryptoHash, Nonce, PublicKey, TxExecutionStatus,
+    BlockHeight, CryptoHash, Nonce, PublicKey,
     transaction::{
         PrepopulateTransaction, SignedTransaction,
         delegate_action::{SignedDelegateAction, SignedDelegateActionAsBase64},
@@ -35,7 +34,7 @@ const META_EXECUTOR_TARGET: &str = "near_api::meta::executor";
 
 /// Internal enum to distinguish between a full RPC response and a minimal pending response.
 enum SendImplResponse {
-    Full(Box<RpcTransactionResponse>),
+    Full(Box<FinalExecutionOutcomeView>),
     Pending(TxExecutionStatus),
 }
 
@@ -46,20 +45,6 @@ impl fmt::Debug for SendImplResponse {
             Self::Pending(status) => write!(f, "Pending({status:?})"),
         }
     }
-}
-
-/// Minimal JSON-RPC response returned when `wait_until` is `NONE` or `INCLUDED`.
-///
-/// The RPC returns only `{"jsonrpc":"2.0","result":{"final_execution_status":"..."},"id":"0"}`
-/// which doesn't match the full `RpcTransactionResponse` schema.
-#[derive(serde::Deserialize)]
-struct MinimalTransactionResponse {
-    result: MinimalTransactionResult,
-}
-
-#[derive(serde::Deserialize)]
-struct MinimalTransactionResult {
-    final_execution_status: TxExecutionStatus,
 }
 
 #[async_trait::async_trait]
@@ -296,69 +281,58 @@ impl ExecuteSignedTransaction {
         wait_until: TxExecutionStatus,
     ) -> Result<TransactionResult, ExecuteTransactionError> {
         let hash = signed_tr.get_hash();
-        let signed_tx_base64: near_openapi_client::types::SignedTransaction = signed_tr.into();
+        let signed_tx_base64: OpenRpcSignedTransaction = signed_tr.into();
         let result = retry(network.clone(), |client| {
             let signed_tx_base64 = signed_tx_base64.clone();
             async move {
                 let result = match client
-                    .send_tx(&JsonRpcRequestForSendTx {
-                        id: "0".to_string(),
-                        jsonrpc: "2.0".to_string(),
-                        method: near_openapi_client::types::JsonRpcRequestForSendTxMethod::SendTx,
-                        params: RpcSendTransactionRequest {
+                    .call::<_, RpcTransactionResponse>(
+                        "send_tx",
+                        RpcSendTransactionRequest {
                             signed_tx_base64,
                             wait_until,
                         },
-                    })
+                    )
                     .await
-                    .map(|r| r.into_inner())
                     .map_err(SendRequestError::from)
                 {
-                    Ok(
-                        JsonRpcResponseForRpcTransactionResponseAndRpcTransactionError::Variant0 {
-                            result,
-                            ..
-                        },
-                    ) => RetryResponse::Ok(SendImplResponse::Full(Box::new(result))),
-                    Ok(
-                        JsonRpcResponseForRpcTransactionResponseAndRpcTransactionError::Variant1 {
-                            error,
-                            ..
-                        },
-                    ) => {
-                        let error: SendRequestError<RpcTransactionError> =
-                            SendRequestError::from(error);
-                        to_retry_error(error, is_critical_transaction_error)
-                    }
-                    Err(err) => {
-                        // When wait_until is NONE or INCLUDED, the RPC returns a minimal
-                        // response with only `final_execution_status`. The openapi client
-                        // fails to deserialize this into RpcTransactionResponse (which
-                        // expects full execution data) and returns InvalidResponsePayload.
-                        // We intercept this case and parse the minimal response ourselves.
-                        //
-                        // We only attempt this fallback when we explicitly requested a
-                        // minimal response, so unexpected/buggy RPC responses for higher
-                        // finality levels don't get silently treated as Pending.
-                        if matches!(
-                            wait_until,
-                            TxExecutionStatus::None | TxExecutionStatus::Included
-                        ) {
-                            if let SendRequestError::TransportError(
-                                near_openapi_client::Error::InvalidResponsePayload(ref bytes, _),
-                            ) = err
-                            {
-                                if let Ok(minimal) =
-                                    serde_json::from_slice::<MinimalTransactionResponse>(bytes)
-                                {
-                                    return RetryResponse::Ok(SendImplResponse::Pending(
-                                        minimal.result.final_execution_status,
-                                    ));
-                                }
-                            }
-                        }
-                        to_retry_error(err, is_critical_transaction_error)
-                    }
+                    Ok(rpc_response) => match rpc_response {
+                        RpcTransactionResponse::Empty {
+                            final_execution_status,
+                        } => RetryResponse::Ok(SendImplResponse::Pending(
+                            final_execution_status,
+                        )),
+                        RpcTransactionResponse::FinalExecutionOutcomeView {
+                            final_execution_status: _,
+                            receipts_outcome,
+                            status,
+                            transaction,
+                            transaction_outcome,
+                        } => RetryResponse::Ok(SendImplResponse::Full(Box::new(
+                            FinalExecutionOutcomeView {
+                                receipts_outcome,
+                                status,
+                                transaction,
+                                transaction_outcome,
+                            },
+                        ))),
+                        RpcTransactionResponse::FinalExecutionOutcomeWithReceiptView {
+                            final_execution_status: _,
+                            receipts: _,
+                            receipts_outcome,
+                            status,
+                            transaction,
+                            transaction_outcome,
+                        } => RetryResponse::Ok(SendImplResponse::Full(Box::new(
+                            FinalExecutionOutcomeView {
+                                receipts_outcome,
+                                status,
+                                transaction,
+                                transaction_outcome,
+                            },
+                        ))),
+                    },
+                    Err(err) => to_retry_error(err, is_critical_transaction_error),
                 };
 
                 tracing::debug!(
@@ -376,38 +350,9 @@ impl ExecuteSignedTransaction {
 
         match result {
             SendImplResponse::Pending(status) => Ok(TransactionResult::Pending { status }),
-            SendImplResponse::Full(rpc_response) => {
-                let final_execution_outcome_view = match *rpc_response {
-                    // We don't use `experimental_tx`, so we can ignore that, but just to be safe
-                    RpcTransactionResponse::Variant0 {
-                        final_execution_status: _,
-                        receipts: _,
-                        receipts_outcome,
-                        status,
-                        transaction,
-                        transaction_outcome,
-                    } => FinalExecutionOutcomeView {
-                        receipts_outcome,
-                        status,
-                        transaction,
-                        transaction_outcome,
-                    },
-                    RpcTransactionResponse::Variant1 {
-                        final_execution_status: _,
-                        receipts_outcome,
-                        status,
-                        transaction,
-                        transaction_outcome,
-                    } => FinalExecutionOutcomeView {
-                        receipts_outcome,
-                        status,
-                        transaction,
-                        transaction_outcome,
-                    },
-                };
-
+            SendImplResponse::Full(final_execution_outcome_view) => {
                 Ok(TransactionResult::Full(Box::new(
-                    ExecutionFinalResult::try_from(final_execution_outcome_view)?,
+                    ExecutionFinalResult::try_from(*final_execution_outcome_view)?,
                 )))
             }
         }
@@ -632,21 +577,5 @@ impl ExecuteMetaTransaction {
             transaction.delegate_action.receiver_id
         );
         Ok(resp)
-    }
-}
-
-impl From<ErrorWrapperForRpcTransactionError> for SendRequestError<RpcTransactionError> {
-    fn from(err: ErrorWrapperForRpcTransactionError) -> Self {
-        match err {
-            ErrorWrapperForRpcTransactionError::InternalError(internal_error) => {
-                Self::InternalError(internal_error)
-            }
-            ErrorWrapperForRpcTransactionError::RequestValidationError(
-                rpc_request_validation_error_kind,
-            ) => Self::RequestValidationError(rpc_request_validation_error_kind),
-            ErrorWrapperForRpcTransactionError::HandlerError(server_error) => {
-                Self::ServerError(server_error)
-            }
-        }
     }
 }

--- a/api/src/common/utils.rs
+++ b/api/src/common/utils.rs
@@ -105,7 +105,7 @@ fn is_critical_json_rpc_error(
         SendRequestError::TransportError(err) => match err {
             RpcCallError::Http(e) => {
                 use reqwest::StatusCode;
-                e.status().map_or(false, |s| {
+                e.status().is_some_and(|s| {
                     !matches!(
                         s,
                         StatusCode::REQUEST_TIMEOUT

--- a/api/src/common/utils.rs
+++ b/api/src/common/utils.rs
@@ -2,11 +2,7 @@ use base64::{Engine, prelude::BASE64_STANDARD};
 use near_api_types::NearToken;
 use near_openrpc_client::{RpcError, RpcTransactionError};
 
-use crate::{
-    config::RetryResponse,
-    errors::SendRequestError,
-    rpc_client::RpcCallError,
-};
+use crate::{config::RetryResponse, errors::SendRequestError, rpc_client::RpcCallError};
 
 pub fn to_base64(input: &[u8]) -> String {
     BASE64_STANDARD.encode(input)
@@ -52,7 +48,9 @@ pub fn is_critical_query_error(err: &SendRequestError) -> bool {
 pub fn is_critical_transaction_error(err: &SendRequestError) -> bool {
     is_critical_json_rpc_error(err, |rpc_err| {
         match rpc_err.try_cause_as::<RpcTransactionError>() {
-            Some(Ok(RpcTransactionError::TimeoutError | RpcTransactionError::RequestRouted { .. })) => false,
+            Some(Ok(
+                RpcTransactionError::TimeoutError | RpcTransactionError::RequestRouted { .. },
+            )) => false,
             _ => true,
         }
     })
@@ -90,11 +88,9 @@ pub fn is_critical_receipt_error(err: &SendRequestError) -> bool {
 /// Light client proof errors: UNKNOWN_BLOCK, INTERNAL_ERROR, UNAVAILABLE_SHARD are retryable.
 /// INCONSISTENT_STATE, NOT_CONFIRMED, UNKNOWN_TRANSACTION_OR_RECEIPT are critical.
 pub fn is_critical_light_client_proof_error(err: &SendRequestError) -> bool {
-    is_critical_json_rpc_error(err, |rpc_err| {
-        match rpc_err.cause_name() {
-            Some("UNKNOWN_BLOCK" | "INTERNAL_ERROR" | "UNAVAILABLE_SHARD") => false,
-            _ => true,
-        }
+    is_critical_json_rpc_error(err, |rpc_err| match rpc_err.cause_name() {
+        Some("UNKNOWN_BLOCK" | "INTERNAL_ERROR" | "UNAVAILABLE_SHARD") => false,
+        _ => true,
     })
 }
 

--- a/api/src/common/utils.rs
+++ b/api/src/common/utils.rs
@@ -3,12 +3,12 @@
 
 use base64::{Engine, prelude::BASE64_STANDARD};
 use near_api_types::NearToken;
-use near_openapi_client::types::{
-    RpcBlockError, RpcQueryError, RpcTransactionError, RpcValidatorError,
-};
-use reqwest::StatusCode;
 
-use crate::{config::RetryResponse, errors::SendRequestError};
+use crate::{
+    config::RetryResponse,
+    errors::SendRequestError,
+    rpc_client::{RpcCallError, RpcError},
+};
 
 pub fn to_base64(input: &[u8]) -> String {
     BASE64_STANDARD.encode(input)
@@ -23,10 +23,10 @@ pub const fn near_data_to_near_token(data: near_api_types::Data<u128>) -> NearTo
     NearToken::from_yoctonear(data.data)
 }
 
-pub fn to_retry_error<T, E: std::fmt::Debug + Send + Sync>(
-    err: SendRequestError<E>,
-    is_critical_t: impl Fn(&SendRequestError<E>) -> bool,
-) -> RetryResponse<T, SendRequestError<E>> {
+pub fn to_retry_error<T>(
+    err: SendRequestError,
+    is_critical_t: impl Fn(&SendRequestError) -> bool,
+) -> RetryResponse<T, SendRequestError> {
     if is_critical_t(&err) {
         RetryResponse::Critical(err)
     } else {
@@ -34,90 +34,88 @@ pub fn to_retry_error<T, E: std::fmt::Debug + Send + Sync>(
     }
 }
 
-pub fn is_critical_blocks_error(err: &SendRequestError<RpcBlockError>) -> bool {
-    is_critical_json_rpc_error(err, |err| match err {
-        RpcBlockError::UnknownBlock { .. }
-        | RpcBlockError::NotSyncedYet
-        | RpcBlockError::InternalError { .. } => false,
-        _ => false,
+pub fn is_critical_blocks_error(err: &SendRequestError) -> bool {
+    is_critical_json_rpc_error(err, |rpc_err| {
+        match rpc_err.cause_name() {
+            Some("UNKNOWN_BLOCK") | Some("NOT_SYNCED_YET") | Some("INTERNAL_ERROR") => false,
+            _ => false,
+        }
     })
 }
 
-pub fn is_critical_validator_error(err: &SendRequestError<RpcValidatorError>) -> bool {
-    is_critical_json_rpc_error(err, |err| match err {
-        RpcValidatorError::UnknownEpoch
-        | RpcValidatorError::ValidatorInfoUnavailable
-        | RpcValidatorError::InternalError { .. } => false,
-        _ => false,
-    })
-}
-pub fn is_critical_query_error(err: &SendRequestError<RpcQueryError>) -> bool {
-    is_critical_json_rpc_error(err, |err| match err {
-        RpcQueryError::NoSyncedBlocks
-        | RpcQueryError::UnavailableShard { .. }
-        | RpcQueryError::UnknownBlock { .. }
-        | RpcQueryError::InternalError { .. } => false,
-
-        RpcQueryError::GarbageCollectedBlock { .. }
-        | RpcQueryError::InvalidAccount { .. }
-        | RpcQueryError::UnknownAccount { .. }
-        | RpcQueryError::NoContractCode { .. }
-        | RpcQueryError::TooLargeContractState { .. }
-        | RpcQueryError::UnknownAccessKey { .. }
-        | RpcQueryError::ContractExecutionError { .. }
-        | RpcQueryError::UnknownGasKey { .. } => true,
-
-        // Might be critical, but also might not yet propagated across the network, so we will retry
-        RpcQueryError::NoGlobalContractCode { .. } => false,
-        _ => false,
-    })
-}
-
-pub fn is_critical_transaction_error(err: &SendRequestError<RpcTransactionError>) -> bool {
-    is_critical_json_rpc_error(err, |err| match err {
-        RpcTransactionError::TimeoutError | RpcTransactionError::RequestRouted { .. } => false,
-        RpcTransactionError::InvalidTransaction { .. }
-        | RpcTransactionError::DoesNotTrackShard
-        | RpcTransactionError::UnknownTransaction { .. }
-        | RpcTransactionError::InternalError { .. } => true,
-        _ => false,
-    })
-}
-
-fn is_critical_json_rpc_error<RpcError: std::fmt::Debug + Send + Sync>(
-    err: &SendRequestError<RpcError>,
-    is_critical_t: impl Fn(&RpcError) -> bool,
-) -> bool {
-    match err {
-        SendRequestError::ServerError(rpc_error) => is_critical_t(rpc_error),
-        SendRequestError::WasmExecutionError(_) => true,
-        SendRequestError::InternalError { .. } => false,
-        SendRequestError::RequestValidationError(_) => true,
-        SendRequestError::RequestCreationError(_) => true,
-        SendRequestError::TransportError(error) => match error {
-            near_openapi_client::Error::InvalidRequest(_)
-            | near_openapi_client::Error::CommunicationError(_)
-            | near_openapi_client::Error::InvalidUpgrade(_)
-            | near_openapi_client::Error::ResponseBodyError(_)
-            | near_openapi_client::Error::InvalidResponsePayload(_, _)
-            | near_openapi_client::Error::UnexpectedResponse(_)
-            | near_openapi_client::Error::Custom(_) => true,
-
-            near_openapi_client::Error::ErrorResponse(response_value) => {
-                // It's more readable to use a match statement than a macro
-                #[allow(clippy::match_like_matches_macro)]
-                match response_value.status() {
-                    StatusCode::REQUEST_TIMEOUT
-                    | StatusCode::TOO_MANY_REQUESTS
-                    | StatusCode::INTERNAL_SERVER_ERROR
-                    | StatusCode::BAD_GATEWAY
-                    | StatusCode::SERVICE_UNAVAILABLE
-                    | StatusCode::GATEWAY_TIMEOUT => false,
-                    _ => true,
-                }
+pub fn is_critical_validator_error(err: &SendRequestError) -> bool {
+    is_critical_json_rpc_error(err, |rpc_err| {
+        match rpc_err.cause_name() {
+            Some("UNKNOWN_EPOCH") | Some("VALIDATOR_INFO_UNAVAILABLE") | Some("INTERNAL_ERROR") => {
+                false
             }
             _ => false,
+        }
+    })
+}
+
+pub fn is_critical_query_error(err: &SendRequestError) -> bool {
+    is_critical_json_rpc_error(err, |rpc_err| {
+        match rpc_err.cause_name() {
+            Some("NO_SYNCED_BLOCKS") | Some("UNAVAILABLE_SHARD") | Some("UNKNOWN_BLOCK")
+            | Some("INTERNAL_ERROR") => false,
+
+            Some("GARBAGE_COLLECTED_BLOCK")
+            | Some("INVALID_ACCOUNT")
+            | Some("UNKNOWN_ACCOUNT")
+            | Some("NO_CONTRACT_CODE")
+            | Some("TOO_LARGE_CONTRACT_STATE")
+            | Some("UNKNOWN_ACCESS_KEY")
+            | Some("CONTRACT_EXECUTION_ERROR")
+            | Some("UNKNOWN_GAS_KEY") => true,
+
+            // Might be critical, but also might not yet propagated across the network, so we will retry
+            Some("NO_GLOBAL_CONTRACT_CODE") => false,
+            _ => false,
+        }
+    })
+}
+
+pub fn is_critical_transaction_error(err: &SendRequestError) -> bool {
+    is_critical_json_rpc_error(err, |rpc_err| {
+        match rpc_err.cause_name() {
+            Some("TIMEOUT_ERROR") | Some("REQUEST_ROUTED") => false,
+            Some("INVALID_TRANSACTION")
+            | Some("DOES_NOT_TRACK_SHARD")
+            | Some("UNKNOWN_TRANSACTION")
+            | Some("INTERNAL_ERROR") => true,
+            _ => false,
+        }
+    })
+}
+
+fn is_critical_json_rpc_error(
+    err: &SendRequestError,
+    is_critical_handler: impl Fn(&RpcError) -> bool,
+) -> bool {
+    match err {
+        SendRequestError::ServerError(rpc_error) => is_critical_handler(rpc_error),
+        SendRequestError::RequestCreationError(_) => true,
+        SendRequestError::TransportError(err) => match err {
+            RpcCallError::Http(e) => {
+                use reqwest::StatusCode;
+                // Check HTTP status for retryable errors
+                e.status().map_or(false, |s| {
+                    !matches!(
+                        s,
+                        StatusCode::REQUEST_TIMEOUT
+                            | StatusCode::TOO_MANY_REQUESTS
+                            | StatusCode::INTERNAL_SERVER_ERROR
+                            | StatusCode::BAD_GATEWAY
+                            | StatusCode::SERVICE_UNAVAILABLE
+                            | StatusCode::GATEWAY_TIMEOUT
+                    )
+                })
+            }
+            RpcCallError::Deserialize(_) => true,
+            RpcCallError::Rpc(_) => {
+                unreachable!("Rpc errors are converted to ServerError in From<RpcCallError>")
+            }
         },
-        _ => false,
     }
 }

--- a/api/src/common/utils.rs
+++ b/api/src/common/utils.rs
@@ -32,19 +32,16 @@ pub fn to_retry_error<T>(
     }
 }
 
-/// Blocks errors: all known causes are retryable (UNKNOWN_BLOCK, NOT_SYNCED_YET, INTERNAL_ERROR).
-pub fn is_critical_blocks_error(err: &SendRequestError) -> bool {
-    is_critical_json_rpc_error(err, |rpc_err| !rpc_err.is_retryable())
-}
-
-/// Validator errors: all known causes are retryable (UNKNOWN_EPOCH, VALIDATOR_INFO_UNAVAILABLE, INTERNAL_ERROR).
-pub fn is_critical_validator_error(err: &SendRequestError) -> bool {
+/// Generic RPC error criticality check: an error is critical unless `is_retryable()` says otherwise.
+/// Used for blocks, validators, and other RPC methods where all known causes are retryable.
+pub fn is_critical_rpc_error(err: &SendRequestError) -> bool {
     is_critical_json_rpc_error(err, |rpc_err| !rpc_err.is_retryable())
 }
 
 /// Query errors: retryable causes (NO_SYNCED_BLOCKS, UNAVAILABLE_SHARD, UNKNOWN_BLOCK, INTERNAL_ERROR)
 /// are not critical, but permanent errors (INVALID_ACCOUNT, UNKNOWN_ACCOUNT, etc.) are.
 /// NO_GLOBAL_CONTRACT_CODE is treated as retryable since it may not have propagated yet.
+/// ContractExecutionError is always critical (handled by `is_critical_json_rpc_error`).
 pub fn is_critical_query_error(err: &SendRequestError) -> bool {
     is_critical_json_rpc_error(err, |rpc_err| !rpc_err.is_retryable())
 }
@@ -68,6 +65,7 @@ fn is_critical_json_rpc_error(
     match err {
         SendRequestError::ServerError(rpc_error) => is_critical_handler(rpc_error),
         SendRequestError::RequestCreationError(_) => true,
+        SendRequestError::ContractExecutionError(_) => true,
         SendRequestError::TransportError(err) => match err {
             RpcCallError::Http(e) => {
                 use reqwest::StatusCode;

--- a/api/src/common/utils.rs
+++ b/api/src/common/utils.rs
@@ -47,12 +47,12 @@ pub fn is_critical_query_error(err: &SendRequestError) -> bool {
 /// INTERNAL_ERROR is treated as critical for transactions (different from queries).
 pub fn is_critical_transaction_error(err: &SendRequestError) -> bool {
     is_critical_json_rpc_error(err, |rpc_err| {
-        match rpc_err.try_cause_as::<RpcTransactionError>() {
+        !matches!(
+            rpc_err.try_cause_as::<RpcTransactionError>(),
             Some(Ok(
                 RpcTransactionError::TimeoutError | RpcTransactionError::RequestRouted { .. },
-            )) => false,
-            _ => true,
-        }
+            ))
+        )
     })
 }
 
@@ -61,16 +61,14 @@ pub fn is_critical_transaction_error(err: &SendRequestError) -> bool {
 /// Only INVALID_TRANSACTION is critical.
 pub fn is_critical_transaction_status_error(err: &SendRequestError) -> bool {
     is_critical_json_rpc_error(err, |rpc_err| {
-        match rpc_err.try_cause_as::<RpcTransactionError>() {
-            Some(Ok(
-                RpcTransactionError::TimeoutError
+        !matches!(
+            rpc_err.try_cause_as::<RpcTransactionError>(),
+            Some(Ok(RpcTransactionError::TimeoutError
                 | RpcTransactionError::RequestRouted { .. }
                 | RpcTransactionError::UnknownTransaction { .. }
                 | RpcTransactionError::DoesNotTrackShard { .. }
-                | RpcTransactionError::InternalError { .. },
-            )) => false,
-            _ => true,
-        }
+                | RpcTransactionError::InternalError { .. },))
+        )
     })
 }
 
@@ -88,9 +86,11 @@ pub fn is_critical_receipt_error(err: &SendRequestError) -> bool {
 /// Light client proof errors: UNKNOWN_BLOCK, INTERNAL_ERROR, UNAVAILABLE_SHARD are retryable.
 /// INCONSISTENT_STATE, NOT_CONFIRMED, UNKNOWN_TRANSACTION_OR_RECEIPT are critical.
 pub fn is_critical_light_client_proof_error(err: &SendRequestError) -> bool {
-    is_critical_json_rpc_error(err, |rpc_err| match rpc_err.cause_name() {
-        Some("UNKNOWN_BLOCK" | "INTERNAL_ERROR" | "UNAVAILABLE_SHARD") => false,
-        _ => true,
+    is_critical_json_rpc_error(err, |rpc_err| {
+        !matches!(
+            rpc_err.cause_name(),
+            Some("UNKNOWN_BLOCK" | "INTERNAL_ERROR" | "UNAVAILABLE_SHARD")
+        )
     })
 }
 

--- a/api/src/common/utils.rs
+++ b/api/src/common/utils.rs
@@ -1,13 +1,11 @@
-// New errors can be added to the codebase, so we want to handle them gracefully
-#![allow(unreachable_patterns)]
-
 use base64::{Engine, prelude::BASE64_STANDARD};
 use near_api_types::NearToken;
+use near_openrpc_client::{RpcError, RpcTransactionError};
 
 use crate::{
     config::RetryResponse,
     errors::SendRequestError,
-    rpc_client::{RpcCallError, RpcError},
+    rpc_client::RpcCallError,
 };
 
 pub fn to_base64(input: &[u8]) -> String {
@@ -34,57 +32,31 @@ pub fn to_retry_error<T>(
     }
 }
 
+/// Blocks errors: all known causes are retryable (UNKNOWN_BLOCK, NOT_SYNCED_YET, INTERNAL_ERROR).
 pub fn is_critical_blocks_error(err: &SendRequestError) -> bool {
-    is_critical_json_rpc_error(err, |rpc_err| {
-        match rpc_err.cause_name() {
-            Some("UNKNOWN_BLOCK") | Some("NOT_SYNCED_YET") | Some("INTERNAL_ERROR") => false,
-            _ => false,
-        }
-    })
+    is_critical_json_rpc_error(err, |rpc_err| !rpc_err.is_retryable())
 }
 
+/// Validator errors: all known causes are retryable (UNKNOWN_EPOCH, VALIDATOR_INFO_UNAVAILABLE, INTERNAL_ERROR).
 pub fn is_critical_validator_error(err: &SendRequestError) -> bool {
-    is_critical_json_rpc_error(err, |rpc_err| {
-        match rpc_err.cause_name() {
-            Some("UNKNOWN_EPOCH") | Some("VALIDATOR_INFO_UNAVAILABLE") | Some("INTERNAL_ERROR") => {
-                false
-            }
-            _ => false,
-        }
-    })
+    is_critical_json_rpc_error(err, |rpc_err| !rpc_err.is_retryable())
 }
 
+/// Query errors: retryable causes (NO_SYNCED_BLOCKS, UNAVAILABLE_SHARD, UNKNOWN_BLOCK, INTERNAL_ERROR)
+/// are not critical, but permanent errors (INVALID_ACCOUNT, UNKNOWN_ACCOUNT, etc.) are.
+/// NO_GLOBAL_CONTRACT_CODE is treated as retryable since it may not have propagated yet.
 pub fn is_critical_query_error(err: &SendRequestError) -> bool {
-    is_critical_json_rpc_error(err, |rpc_err| {
-        match rpc_err.cause_name() {
-            Some("NO_SYNCED_BLOCKS") | Some("UNAVAILABLE_SHARD") | Some("UNKNOWN_BLOCK")
-            | Some("INTERNAL_ERROR") => false,
-
-            Some("GARBAGE_COLLECTED_BLOCK")
-            | Some("INVALID_ACCOUNT")
-            | Some("UNKNOWN_ACCOUNT")
-            | Some("NO_CONTRACT_CODE")
-            | Some("TOO_LARGE_CONTRACT_STATE")
-            | Some("UNKNOWN_ACCESS_KEY")
-            | Some("CONTRACT_EXECUTION_ERROR")
-            | Some("UNKNOWN_GAS_KEY") => true,
-
-            // Might be critical, but also might not yet propagated across the network, so we will retry
-            Some("NO_GLOBAL_CONTRACT_CODE") => false,
-            _ => false,
-        }
-    })
+    is_critical_json_rpc_error(err, |rpc_err| !rpc_err.is_retryable())
 }
 
+/// Transaction errors: TIMEOUT_ERROR and REQUEST_ROUTED are retryable.
+/// INVALID_TRANSACTION, DOES_NOT_TRACK_SHARD, UNKNOWN_TRANSACTION are critical.
+/// INTERNAL_ERROR is treated as critical for transactions (different from queries).
 pub fn is_critical_transaction_error(err: &SendRequestError) -> bool {
     is_critical_json_rpc_error(err, |rpc_err| {
-        match rpc_err.cause_name() {
-            Some("TIMEOUT_ERROR") | Some("REQUEST_ROUTED") => false,
-            Some("INVALID_TRANSACTION")
-            | Some("DOES_NOT_TRACK_SHARD")
-            | Some("UNKNOWN_TRANSACTION")
-            | Some("INTERNAL_ERROR") => true,
-            _ => false,
+        match rpc_err.try_cause_as::<RpcTransactionError>() {
+            Some(Ok(RpcTransactionError::TimeoutError | RpcTransactionError::RequestRouted { .. })) => false,
+            _ => true,
         }
     })
 }
@@ -99,7 +71,6 @@ fn is_critical_json_rpc_error(
         SendRequestError::TransportError(err) => match err {
             RpcCallError::Http(e) => {
                 use reqwest::StatusCode;
-                // Check HTTP status for retryable errors
                 e.status().map_or(false, |s| {
                     !matches!(
                         s,

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -1,9 +1,21 @@
+use std::sync::LazyLock;
+
 use near_api_types::AccountId;
 use reqwest::header::{HeaderValue, InvalidHeaderValue};
 use url::Url;
 
 use crate::errors::RetryError;
 use crate::rpc_client::RpcClient;
+
+/// Global shared `reqwest::Client` so all RPC calls reuse TCP connections.
+static SHARED_HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    let dur = std::time::Duration::from_secs(15);
+    reqwest::ClientBuilder::new()
+        .connect_timeout(dur)
+        .timeout(dur)
+        .build()
+        .expect("failed to build HTTP client")
+});
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 /// Specifies the retry strategy for RPC endpoint requests.
@@ -102,10 +114,8 @@ impl RPCEndpoint {
     }
 
     pub(crate) fn client(&self) -> Result<RpcClient, InvalidHeaderValue> {
-        let dur = std::time::Duration::from_secs(15);
-        let mut client = reqwest::ClientBuilder::new()
-            .connect_timeout(dur)
-            .timeout(dur);
+        let url = self.url.as_ref().trim_end_matches('/').to_string();
+        let mut client = RpcClient::new(url, SHARED_HTTP_CLIENT.clone());
 
         if let Some(rpc_api_key) = &self.bearer_header {
             let mut headers = reqwest::header::HeaderMap::new();
@@ -121,12 +131,9 @@ impl RPCEndpoint {
                 reqwest::header::HeaderName::from_static("x-api-key"),
                 header,
             );
-            client = client.default_headers(headers);
+            client = client.with_headers(headers);
         };
-        Ok(RpcClient::new(
-            self.url.as_ref().trim_end_matches('/').to_string(),
-            client.build().unwrap(),
-        ))
+        Ok(client)
     }
 }
 

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -1,9 +1,9 @@
 use near_api_types::AccountId;
-use near_openapi_client::Client;
 use reqwest::header::{HeaderValue, InvalidHeaderValue};
 use url::Url;
 
 use crate::errors::RetryError;
+use crate::rpc_client::RpcClient;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 /// Specifies the retry strategy for RPC endpoint requests.
@@ -91,7 +91,7 @@ impl RPCEndpoint {
         }
     }
 
-    pub(crate) fn client(&self) -> Result<Client, InvalidHeaderValue> {
+    pub(crate) fn client(&self) -> Result<RpcClient, InvalidHeaderValue> {
         let dur = std::time::Duration::from_secs(15);
         let mut client = reqwest::ClientBuilder::new()
             .connect_timeout(dur)
@@ -113,8 +113,8 @@ impl RPCEndpoint {
             );
             client = client.default_headers(headers);
         };
-        Ok(near_openapi_client::Client::new_with_client(
-            self.url.as_ref().trim_end_matches('/'),
+        Ok(RpcClient::new(
+            self.url.as_ref().trim_end_matches('/').to_string(),
             client.build().unwrap(),
         ))
     }
@@ -232,7 +232,7 @@ impl<R, E> From<Result<R, E>> for RetryResponse<R, E> {
 /// * `task` - The task to retry.
 pub async fn retry<R, E, T, F>(network: NetworkConfig, mut task: F) -> Result<R, RetryError<E>>
 where
-    F: FnMut(Client) -> T + Send,
+    F: FnMut(RpcClient) -> T + Send,
     T: core::future::Future<Output = RetryResponse<R, E>> + Send,
     T::Output: Send,
     E: Send,

--- a/api/src/contract.rs
+++ b/api/src/contract.rs
@@ -346,7 +346,7 @@ impl Contract {
             })
     }
 
-    /// Prepares a query to fetch the wasm code ([Data]<[ContractCodeView](near_api_types::ContractCodeView)>) of the contract.
+    /// Prepares a query to fetch the wasm code ([Data]<[ContractCodeView](near_openrpc_client::RpcViewCodeResponse)>) of the contract.
     ///
     /// # Example
     /// ```rust,no_run
@@ -407,7 +407,7 @@ impl Contract {
         GlobalWasmBuilder
     }
 
-    /// Prepares a query to fetch the storage of the contract ([Data]<[ViewStateResult](near_api_types::ViewStateResult)>) using the given prefix as a filter.
+    /// Prepares a query to fetch the storage of the contract ([Data]<[ViewStateResult](near_openrpc_client::RpcViewStateResponse)>) using the given prefix as a filter.
     ///
     /// It helpful if you are aware of the storage that you are looking for.
     ///
@@ -438,7 +438,7 @@ impl Contract {
         )
     }
 
-    /// Prepares a query to fetch the storage of the contract ([Data]<[ViewStateResult](near_api_types::ViewStateResult)>).
+    /// Prepares a query to fetch the storage of the contract ([Data]<[ViewStateResult](near_openrpc_client::RpcViewStateResponse)>).
     ///
     /// Please be aware that large storage queries might fail.
     ///
@@ -961,7 +961,7 @@ impl ContractTransactBuilder {
 pub struct GlobalWasmBuilder;
 
 impl GlobalWasmBuilder {
-    /// Prepares a query to fetch global contract code ([Data]<[ContractCodeView](near_api_types::ContractCodeView)>) by account ID.
+    /// Prepares a query to fetch global contract code ([Data]<[ContractCodeView](near_openrpc_client::RpcViewCodeResponse)>) by account ID.
     ///
     /// # Example
     /// ```rust,no_run
@@ -986,7 +986,7 @@ impl GlobalWasmBuilder {
         )
     }
 
-    /// Prepares a query to fetch global contract code ([Data]<[ContractCodeView](near_api_types::ContractCodeView)>) by hash.
+    /// Prepares a query to fetch global contract code ([Data]<[ContractCodeView](near_openrpc_client::RpcViewCodeResponse)>) by hash.
     ///
     /// # Example
     /// ```rust,no_run

--- a/api/src/contract.rs
+++ b/api/src/contract.rs
@@ -346,7 +346,7 @@ impl Contract {
             })
     }
 
-    /// Prepares a query to fetch the wasm code ([Data]<[ContractCodeView](near_openrpc_client::RpcViewCodeResponse)>) of the contract.
+    /// Prepares a query to fetch the wasm code ([Data]<[RpcViewCodeResponse](near_openrpc_client::RpcViewCodeResponse)>) of the contract.
     ///
     /// # Example
     /// ```rust,no_run
@@ -407,9 +407,9 @@ impl Contract {
         GlobalWasmBuilder
     }
 
-    /// Prepares a query to fetch the storage of the contract ([Data]<[ViewStateResult](near_openrpc_client::RpcViewStateResponse)>) using the given prefix as a filter.
+    /// Prepares a query to fetch the storage of the contract ([Data]<[RpcViewStateResponse](near_openrpc_client::RpcViewStateResponse)>) using the given prefix as a filter.
     ///
-    /// It helpful if you are aware of the storage that you are looking for.
+    /// It is helpful if you are aware of the storage that you are looking for.
     ///
     /// # Example
     /// ```rust,no_run
@@ -438,7 +438,7 @@ impl Contract {
         )
     }
 
-    /// Prepares a query to fetch the storage of the contract ([Data]<[ViewStateResult](near_openrpc_client::RpcViewStateResponse)>).
+    /// Prepares a query to fetch the storage of the contract ([Data]<[RpcViewStateResponse](near_openrpc_client::RpcViewStateResponse)>).
     ///
     /// Please be aware that large storage queries might fail.
     ///

--- a/api/src/errors.rs
+++ b/api/src/errors.rs
@@ -14,12 +14,6 @@ pub enum QueryCreationError {
 pub enum QueryError {
     #[error(transparent)]
     QueryCreationError(#[from] QueryCreationError),
-    #[error("Unexpected response kind: expected {expected} type, but got {got:?}")]
-    UnexpectedResponse {
-        expected: &'static str,
-        // Boxed to avoid large error type
-        got: &'static str,
-    },
     #[error("Failed to deserialize response: {0}")]
     DeserializeError(#[from] serde_json::Error),
     #[error("Query error: {0:?}")]
@@ -288,6 +282,8 @@ pub enum SendRequestError {
     TransportError(RpcCallError),
     #[error("Server error: {0}")]
     ServerError(RpcError),
+    #[error("Contract execution error: {0}")]
+    ContractExecutionError(String),
 }
 
 impl SendRequestError {

--- a/api/src/errors.rs
+++ b/api/src/errors.rs
@@ -1,10 +1,6 @@
 use std::sync::Arc;
 
-use near_api_types::errors::DataConversionError;
-use near_openapi_client::types::{
-    FunctionCallError, InternalError, RpcQueryError, RpcRequestValidationErrorKind,
-    RpcTransactionError,
-};
+use crate::rpc_client::{RpcCallError, RpcError};
 
 #[derive(thiserror::Error, Debug)]
 pub enum QueryCreationError {
@@ -13,7 +9,7 @@ pub enum QueryCreationError {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum QueryError<RpcError: std::fmt::Debug + Send + Sync> {
+pub enum QueryError {
     #[error(transparent)]
     QueryCreationError(#[from] QueryCreationError),
     #[error("Unexpected response kind: expected {expected} type, but got {got:?}")]
@@ -25,7 +21,7 @@ pub enum QueryError<RpcError: std::fmt::Debug + Send + Sync> {
     #[error("Failed to deserialize response: {0}")]
     DeserializeError(#[from] serde_json::Error),
     #[error("Query error: {0:?}")]
-    QueryError(Box<RetryError<SendRequestError<RpcError>>>),
+    QueryError(Box<RetryError<SendRequestError>>),
     #[error("Internal error: failed to get response. Please submit a bug ticket")]
     InternalErrorNoResponse,
     #[error("Argument serialization error: {0}")]
@@ -34,10 +30,8 @@ pub enum QueryError<RpcError: std::fmt::Debug + Send + Sync> {
     ConversionError(Box<dyn std::error::Error + Send + Sync>),
 }
 
-impl<RpcError: std::fmt::Debug + Send + Sync> From<RetryError<SendRequestError<RpcError>>>
-    for QueryError<RpcError>
-{
-    fn from(err: RetryError<SendRequestError<RpcError>>) -> Self {
+impl From<RetryError<SendRequestError>> for QueryError {
+    fn from(err: RetryError<SendRequestError>) -> Self {
         Self::QueryError(Box::new(err))
     }
 }
@@ -67,7 +61,7 @@ pub enum SignerError {
     #[error("Secret key is not available")]
     SecretKeyIsNotAvailable,
     #[error("Failed to fetch nonce: {0:?}")]
-    FetchNonceError(Box<QueryError<RpcQueryError>>),
+    FetchNonceError(Box<QueryError>),
     #[error("IO error: {0}")]
     IO(#[from] std::io::Error),
 
@@ -106,7 +100,7 @@ pub enum KeyStoreError {
     #[error(transparent)]
     Keystore(#[from] keyring::Error),
     #[error("Failed to query account keys: {0:?}")]
-    QueryError(QueryError<RpcQueryError>),
+    QueryError(QueryError),
     #[error("Failed to parse access key file: {0}")]
     ParseError(#[from] serde_json::Error),
     #[error(transparent)]
@@ -221,7 +215,7 @@ pub enum ExecuteTransactionError {
     ArgumentValidationError(#[from] ArgumentValidationError),
 
     #[error("Pre-query error: {0:?}")]
-    PreQueryError(QueryError<RpcQueryError>),
+    PreQueryError(QueryError),
     #[error("Transaction validation error: {0}")]
     ValidationError(#[from] ValidationError),
     #[error("Meta-signing error: {0}")]
@@ -230,9 +224,9 @@ pub enum ExecuteTransactionError {
     SignerError(#[from] SignerError),
 
     #[error("Transaction error: {0:?}")]
-    TransactionError(RetryError<SendRequestError<RpcTransactionError>>),
+    TransactionError(RetryError<SendRequestError>),
     #[error("Data conversion error: {0}")]
-    DataConversionError(#[from] DataConversionError),
+    DataConversionError(#[from] near_api_types::errors::DataConversionError),
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -241,7 +235,7 @@ pub enum ExecuteMetaTransactionsError {
     ArgumentValidationError(#[from] ArgumentValidationError),
 
     #[error("Pre-query error: {0:?}")]
-    PreQueryError(QueryError<RpcQueryError>),
+    PreQueryError(QueryError),
     #[error("Transaction validation error: {0}")]
     ValidationError(#[from] ValidationError),
     #[error("Relayer is not defined in the network config")]
@@ -272,7 +266,7 @@ pub enum FTValidatorError {
 #[derive(thiserror::Error, Debug)]
 pub enum ValidationError {
     #[error("Query error: {0:?}")]
-    QueryError(QueryError<RpcQueryError>),
+    QueryError(QueryError),
 
     #[error(transparent)]
     ArgumentValidationError(#[from] ArgumentValidationError),
@@ -285,47 +279,20 @@ pub enum ValidationError {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum SendRequestError<RpcError: std::fmt::Debug + Send + Sync> {
+pub enum SendRequestError {
     #[error("Query creation error: {0}")]
     RequestCreationError(#[from] QueryCreationError),
     #[error("Transport error: {0}")]
-    TransportError(near_openapi_client::Error<()>),
-    // This is a hack to support the old error handling in the RPC API.
-    #[error("Wasm execution failed with error: {0}")]
-    WasmExecutionError(#[from] FunctionCallError),
-    #[error("Internal error: {0:?}")]
-    InternalError(#[from] InternalError),
-    #[error("Request validation error: {0:?}")]
-    RequestValidationError(#[from] RpcRequestValidationErrorKind),
+    TransportError(RpcCallError),
     #[error("Server error: {0}")]
     ServerError(RpcError),
 }
 
-// That's a BIG BIG HACK to handle inconsistent RPC errors
-//
-// Node responds as a message instead of an error object, so we need to parse the message and return the error.
-// https://github.com/near/nearcore/blob/ae6fd841eaad76a090a02e9dcf7406bc79b81dbb/chain/jsonrpc/src/lib.rs#L204
-//
-// TODO: remove this once we have a proper error handling in the RPC API.
-// - https://github.com/near/near-sdk-rs/pull/1165
-// - nearcore PR
-impl<RpcError: std::fmt::Debug + Send + Sync> From<near_openapi_client::Error<()>>
-    for SendRequestError<RpcError>
-{
-    fn from(err: near_openapi_client::Error<()>) -> Self {
-        if let near_openapi_client::Error::InvalidResponsePayload(bytes, _error) = &err {
-            let error = serde_json::from_slice::<serde_json::Value>(bytes)
-                .unwrap_or_default()
-                .get("result")
-                .and_then(|result| result.get("error"))
-                .and_then(|message| message.as_str())
-                .and_then(|message| message.strip_prefix("wasm execution failed with error: "))
-                .and_then(|message| serde_dbgfmt::from_str::<FunctionCallError>(message).ok());
-            if let Some(error) = error {
-                return Self::WasmExecutionError(error);
-            }
+impl From<RpcCallError> for SendRequestError {
+    fn from(err: RpcCallError) -> Self {
+        match err {
+            RpcCallError::Rpc(rpc_err) => Self::ServerError(rpc_err),
+            other => Self::TransportError(other),
         }
-
-        Self::TransportError(err)
     }
 }

--- a/api/src/errors.rs
+++ b/api/src/errors.rs
@@ -322,7 +322,7 @@ impl SendRequestError {
 impl From<RpcCallError> for SendRequestError {
     fn from(err: RpcCallError) -> Self {
         match err {
-            RpcCallError::Rpc(rpc_err) => Self::ServerError(rpc_err),
+            RpcCallError::Rpc(rpc_err) => Self::ServerError(*rpc_err),
             other => Self::TransportError(other),
         }
     }

--- a/api/src/errors.rs
+++ b/api/src/errors.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use crate::rpc_client::{RpcCallError, RpcError};
+use crate::rpc_client::RpcCallError;
+use near_openrpc_client::RpcError;
+use serde::Deserialize;
 
 #[derive(thiserror::Error, Debug)]
 pub enum QueryCreationError {
@@ -286,6 +288,39 @@ pub enum SendRequestError {
     TransportError(RpcCallError),
     #[error("Server error: {0}")]
     ServerError(RpcError),
+}
+
+impl SendRequestError {
+    /// Returns the underlying [`RpcError`] if this is a server error.
+    pub fn as_rpc_error(&self) -> Option<&RpcError> {
+        match self {
+            Self::ServerError(e) => Some(e),
+            _ => None,
+        }
+    }
+
+    /// Attempts to deserialize the RPC error cause into a typed per-method error enum.
+    ///
+    /// Convenience wrapper around [`RpcError::try_cause_as`]. Returns `None` if
+    /// this isn't a server error or if the server error has no cause.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use near_openrpc_client::errors::RpcQueryError;
+    ///
+    /// match send_err.try_cause_as::<RpcQueryError>() {
+    ///     Some(Ok(RpcQueryError::UnknownAccount { requested_account_id, .. })) => {
+    ///         println!("Account {requested_account_id} not found");
+    ///     }
+    ///     _ => {}
+    /// }
+    /// ```
+    pub fn try_cause_as<T: for<'de> Deserialize<'de>>(
+        &self,
+    ) -> Option<Result<T, serde_json::Error>> {
+        self.as_rpc_error()?.try_cause_as()
+    }
 }
 
 impl From<RpcCallError> for SendRequestError {

--- a/api/src/errors.rs
+++ b/api/src/errors.rs
@@ -288,7 +288,7 @@ pub enum SendRequestError {
 
 impl SendRequestError {
     /// Returns the underlying [`RpcError`] if this is a server error.
-    pub fn as_rpc_error(&self) -> Option<&RpcError> {
+    pub const fn as_rpc_error(&self) -> Option<&RpcError> {
         match self {
             Self::ServerError(e) => Some(e),
             _ => None,

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -62,6 +62,7 @@ mod transactions;
 // mod fastnear;
 
 mod common;
+pub mod rpc_client;
 
 pub use near_api_types as types;
 pub mod errors;

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -66,6 +66,8 @@ pub mod rpc_client;
 
 pub use near_api_types as types;
 pub mod errors;
+/// Re-export per-method RPC error enums for typed error matching via [`errors::SendRequestError::try_cause_as`].
+pub use near_openrpc_client::errors as rpc_errors;
 pub mod signer;
 
 pub use crate::{

--- a/api/src/rpc_client.rs
+++ b/api/src/rpc_client.rs
@@ -12,6 +12,7 @@ pub use near_openrpc_client::errors;
 pub struct RpcClient {
     pub(crate) client: reqwest::Client,
     pub(crate) url: String,
+    pub(crate) headers: Option<reqwest::header::HeaderMap>,
 }
 
 /// JSON-RPC request envelope.
@@ -45,8 +46,17 @@ pub enum RpcCallError {
 }
 
 impl RpcClient {
-    pub const fn new(url: String, client: reqwest::Client) -> Self {
-        Self { client, url }
+    pub fn new(url: String, client: reqwest::Client) -> Self {
+        Self {
+            client,
+            url,
+            headers: None,
+        }
+    }
+
+    pub fn with_headers(mut self, headers: reqwest::header::HeaderMap) -> Self {
+        self.headers = Some(headers);
+        self
     }
 
     /// Make a JSON-RPC call with the given method and params.
@@ -62,15 +72,12 @@ impl RpcClient {
             params,
         };
 
-        let bytes = self
-            .client
-            .post(&self.url)
-            .json(&request)
-            .send()
-            .await?
-            .error_for_status()?
-            .bytes()
-            .await?;
+        let mut req = self.client.post(&self.url).json(&request);
+        if let Some(headers) = &self.headers {
+            req = req.headers(headers.clone());
+        }
+
+        let bytes = req.send().await?.error_for_status()?.bytes().await?;
 
         let response: RpcResponse =
             serde_json::from_slice(&bytes).map_err(RpcCallError::Deserialize)?;

--- a/api/src/rpc_client.rs
+++ b/api/src/rpc_client.rs
@@ -1,0 +1,140 @@
+use serde::{Deserialize, Serialize};
+
+/// Thin JSON-RPC 2.0 client wrapping `reqwest::Client`.
+///
+/// This replaces the OpenAPI-generated client with a minimal transport
+/// that sends raw JSON-RPC requests and deserializes responses using
+/// the OpenRPC-generated types.
+#[derive(Debug, Clone)]
+pub struct RpcClient {
+    pub(crate) client: reqwest::Client,
+    pub(crate) url: String,
+}
+
+/// JSON-RPC request envelope.
+#[derive(Debug, Serialize)]
+struct RpcRequest<P> {
+    jsonrpc: &'static str,
+    id: &'static str,
+    method: &'static str,
+    params: P,
+}
+
+/// Raw JSON-RPC response envelope — deserialized as `Value` first to avoid
+/// issues with `serde(flatten)` + `serde(untagged)`.
+#[derive(Debug, Deserialize)]
+struct RpcResponse {
+    #[serde(default)]
+    result: Option<serde_json::Value>,
+    #[serde(default)]
+    error: Option<RpcError>,
+}
+
+/// Error from a JSON-RPC call.
+///
+/// NEAR's RPC extends standard JSON-RPC errors with `name` and `cause` fields
+/// that carry structured, typed error information.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RpcError {
+    pub code: i64,
+    pub message: String,
+    /// Deprecated by nearcore. Prefer `cause` for structured error data.
+    #[serde(default)]
+    pub data: Option<serde_json::Value>,
+    /// Error category: `HANDLER_ERROR`, `REQUEST_VALIDATION_ERROR`, or `INTERNAL_ERROR`.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Structured error detail with per-method error variant name and info.
+    #[serde(default)]
+    pub cause: Option<RpcErrorCause>,
+}
+
+/// Structured cause of an RPC error.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RpcErrorCause {
+    /// The error variant name (e.g., `UNKNOWN_BLOCK`, `INVALID_ACCOUNT`).
+    pub name: String,
+    /// Additional structured information about the error.
+    #[serde(default)]
+    pub info: Option<serde_json::Value>,
+}
+
+impl RpcError {
+    pub fn is_handler_error(&self) -> bool {
+        self.name.as_deref() == Some("HANDLER_ERROR")
+    }
+
+    pub fn is_request_validation_error(&self) -> bool {
+        self.name.as_deref() == Some("REQUEST_VALIDATION_ERROR")
+    }
+
+    pub fn is_internal_error(&self) -> bool {
+        self.name.as_deref() == Some("INTERNAL_ERROR")
+    }
+
+    pub fn cause_name(&self) -> Option<&str> {
+        self.cause.as_ref().map(|c| c.name.as_str())
+    }
+}
+
+impl std::fmt::Display for RpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RPC error {}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for RpcError {}
+
+/// Errors that can occur when making a JSON-RPC call.
+#[derive(Debug, thiserror::Error)]
+pub enum RpcCallError {
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("RPC error: {0}")]
+    Rpc(RpcError),
+    #[error("JSON deserialization error: {0}")]
+    Deserialize(serde_json::Error),
+}
+
+impl RpcClient {
+    pub fn new(url: String, client: reqwest::Client) -> Self {
+        Self { client, url }
+    }
+
+    /// Make a JSON-RPC call with the given method and params.
+    pub async fn call<P: Serialize, R: for<'de> Deserialize<'de>>(
+        &self,
+        method: &'static str,
+        params: P,
+    ) -> Result<R, RpcCallError> {
+        let request = RpcRequest {
+            jsonrpc: "2.0",
+            id: "0",
+            method,
+            params,
+        };
+
+        let bytes = self
+            .client
+            .post(&self.url)
+            .json(&request)
+            .send()
+            .await?
+            .bytes()
+            .await?;
+
+        let response: RpcResponse =
+            serde_json::from_slice(&bytes).map_err(RpcCallError::Deserialize)?;
+
+        if let Some(error) = response.error {
+            return Err(RpcCallError::Rpc(error));
+        }
+
+        match response.result {
+            Some(value) => serde_json::from_value(value).map_err(RpcCallError::Deserialize),
+            None => Err(RpcCallError::Deserialize(serde::de::Error::custom(
+                "response has neither result nor error",
+            ))),
+        }
+    }
+}

--- a/api/src/rpc_client.rs
+++ b/api/src/rpc_client.rs
@@ -46,7 +46,7 @@ pub enum RpcCallError {
 }
 
 impl RpcClient {
-    pub fn new(url: String, client: reqwest::Client) -> Self {
+    pub const fn new(url: String, client: reqwest::Client) -> Self {
         Self {
             client,
             url,

--- a/api/src/rpc_client.rs
+++ b/api/src/rpc_client.rs
@@ -1,4 +1,7 @@
+use near_openrpc_client::RpcError;
 use serde::{Deserialize, Serialize};
+
+pub use near_openrpc_client::errors;
 
 /// Thin JSON-RPC 2.0 client wrapping `reqwest::Client`.
 ///
@@ -29,61 +32,6 @@ struct RpcResponse {
     #[serde(default)]
     error: Option<RpcError>,
 }
-
-/// Error from a JSON-RPC call.
-///
-/// NEAR's RPC extends standard JSON-RPC errors with `name` and `cause` fields
-/// that carry structured, typed error information.
-#[derive(Debug, Clone, Deserialize)]
-pub struct RpcError {
-    pub code: i64,
-    pub message: String,
-    /// Deprecated by nearcore. Prefer `cause` for structured error data.
-    #[serde(default)]
-    pub data: Option<serde_json::Value>,
-    /// Error category: `HANDLER_ERROR`, `REQUEST_VALIDATION_ERROR`, or `INTERNAL_ERROR`.
-    #[serde(default)]
-    pub name: Option<String>,
-    /// Structured error detail with per-method error variant name and info.
-    #[serde(default)]
-    pub cause: Option<RpcErrorCause>,
-}
-
-/// Structured cause of an RPC error.
-#[derive(Debug, Clone, Deserialize)]
-pub struct RpcErrorCause {
-    /// The error variant name (e.g., `UNKNOWN_BLOCK`, `INVALID_ACCOUNT`).
-    pub name: String,
-    /// Additional structured information about the error.
-    #[serde(default)]
-    pub info: Option<serde_json::Value>,
-}
-
-impl RpcError {
-    pub fn is_handler_error(&self) -> bool {
-        self.name.as_deref() == Some("HANDLER_ERROR")
-    }
-
-    pub fn is_request_validation_error(&self) -> bool {
-        self.name.as_deref() == Some("REQUEST_VALIDATION_ERROR")
-    }
-
-    pub fn is_internal_error(&self) -> bool {
-        self.name.as_deref() == Some("INTERNAL_ERROR")
-    }
-
-    pub fn cause_name(&self) -> Option<&str> {
-        self.cause.as_ref().map(|c| c.name.as_str())
-    }
-}
-
-impl std::fmt::Display for RpcError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "RPC error {}: {}", self.code, self.message)
-    }
-}
-
-impl std::error::Error for RpcError {}
 
 /// Errors that can occur when making a JSON-RPC call.
 #[derive(Debug, thiserror::Error)]

--- a/api/src/rpc_client.rs
+++ b/api/src/rpc_client.rs
@@ -39,7 +39,7 @@ pub enum RpcCallError {
     #[error("HTTP error: {0}")]
     Http(#[from] reqwest::Error),
     #[error("RPC error: {0}")]
-    Rpc(RpcError),
+    Rpc(Box<RpcError>),
     #[error("JSON deserialization error: {0}")]
     Deserialize(serde_json::Error),
 }
@@ -75,7 +75,7 @@ impl RpcClient {
             serde_json::from_slice(&bytes).map_err(RpcCallError::Deserialize)?;
 
         if let Some(error) = response.error {
-            return Err(RpcCallError::Rpc(error));
+            return Err(RpcCallError::Rpc(Box::new(error)));
         }
 
         response.result.map_or_else(

--- a/api/src/rpc_client.rs
+++ b/api/src/rpc_client.rs
@@ -68,6 +68,7 @@ impl RpcClient {
             .json(&request)
             .send()
             .await?
+            .error_for_status()?
             .bytes()
             .await?;
 

--- a/api/src/rpc_client.rs
+++ b/api/src/rpc_client.rs
@@ -45,7 +45,7 @@ pub enum RpcCallError {
 }
 
 impl RpcClient {
-    pub fn new(url: String, client: reqwest::Client) -> Self {
+    pub const fn new(url: String, client: reqwest::Client) -> Self {
         Self { client, url }
     }
 
@@ -78,11 +78,13 @@ impl RpcClient {
             return Err(RpcCallError::Rpc(error));
         }
 
-        match response.result {
-            Some(value) => serde_json::from_value(value).map_err(RpcCallError::Deserialize),
-            None => Err(RpcCallError::Deserialize(serde::de::Error::custom(
-                "response has neither result nor error",
-            ))),
-        }
+        response.result.map_or_else(
+            || {
+                Err(RpcCallError::Deserialize(serde::de::Error::custom(
+                    "response has neither result nor error",
+                )))
+            },
+            |value| serde_json::from_value(value).map_err(RpcCallError::Deserialize),
+        )
     }
 }

--- a/api/src/stake.rs
+++ b/api/src/stake.rs
@@ -1,10 +1,10 @@
 use std::collections::BTreeMap;
 
+use crate::rpc_client::RpcClient;
 use near_api_types::{
     AccountId, Data, EpochReference, NearGas, NearToken, Reference,
     stake::{RewardFeeFraction, StakingPoolInfo, UserStakeBalance},
 };
-use crate::rpc_client::RpcClient;
 
 use crate::{
     NetworkConfig,
@@ -561,8 +561,7 @@ impl Staking {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn validators_stake()
-    -> RequestBuilder<
+    pub fn validators_stake() -> RequestBuilder<
         crate::advanced::AndThenHandler<BTreeMap<AccountId, NearToken>, RpcValidatorHandler>,
     > {
         fn parse_near_token(
@@ -584,13 +583,22 @@ impl Staking {
         .and_then(|validator_response| {
             let mut result = BTreeMap::new();
             for v in &validator_response.current_proposals {
-                result.insert(parse_account_id(&v.account_id)?, parse_near_token(&v.stake)?);
+                result.insert(
+                    parse_account_id(&v.account_id)?,
+                    parse_near_token(&v.stake)?,
+                );
             }
             for v in &validator_response.current_validators {
-                result.insert(parse_account_id(&v.account_id)?, parse_near_token(&v.stake)?);
+                result.insert(
+                    parse_account_id(&v.account_id)?,
+                    parse_near_token(&v.stake)?,
+                );
             }
             for v in &validator_response.next_validators {
-                result.insert(parse_account_id(&v.account_id)?, parse_near_token(&v.stake)?);
+                result.insert(
+                    parse_account_id(&v.account_id)?,
+                    parse_near_token(&v.stake)?,
+                );
             }
             Ok(result)
         })

--- a/api/src/stake.rs
+++ b/api/src/stake.rs
@@ -4,7 +4,7 @@ use near_api_types::{
     AccountId, Data, EpochReference, NearGas, NearToken, Reference,
     stake::{RewardFeeFraction, StakingPoolInfo, UserStakeBalance},
 };
-use near_openapi_client::types::{RpcQueryError, RpcQueryResponse};
+use crate::rpc_client::RpcClient;
 
 use crate::{
     NetworkConfig,
@@ -562,36 +562,37 @@ impl Staking {
     /// # }
     /// ```
     pub fn validators_stake()
-    -> RequestBuilder<PostprocessHandler<BTreeMap<AccountId, NearToken>, RpcValidatorHandler>> {
+    -> RequestBuilder<
+        crate::advanced::AndThenHandler<BTreeMap<AccountId, NearToken>, RpcValidatorHandler>,
+    > {
+        fn parse_near_token(
+            s: &near_openrpc_client::NearToken,
+        ) -> Result<NearToken, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(NearToken::from_yoctonear(s.parse::<u128>()?))
+        }
+        fn parse_account_id(
+            s: &near_openrpc_client::AccountId,
+        ) -> Result<AccountId, Box<dyn std::error::Error + Send + Sync>> {
+            Ok(s.parse::<AccountId>()?)
+        }
+
         RequestBuilder::new(
             SimpleValidatorRpc,
             EpochReference::Latest,
             RpcValidatorHandler,
         )
-        .map(|validator_response| {
-            validator_response
-                .current_proposals
-                .into_iter()
-                .map(|validator_stake_view| {
-                    (validator_stake_view.account_id, validator_stake_view.stake)
-                })
-                .chain(validator_response.current_validators.into_iter().map(
-                    |current_epoch_validator_info| {
-                        (
-                            current_epoch_validator_info.account_id,
-                            current_epoch_validator_info.stake,
-                        )
-                    },
-                ))
-                .chain(validator_response.next_validators.into_iter().map(
-                    |next_epoch_validator_info| {
-                        (
-                            next_epoch_validator_info.account_id,
-                            next_epoch_validator_info.stake,
-                        )
-                    },
-                ))
-                .collect::<BTreeMap<_, NearToken>>()
+        .and_then(|validator_response| {
+            let mut result = BTreeMap::new();
+            for v in &validator_response.current_proposals {
+                result.insert(parse_account_id(&v.account_id)?, parse_near_token(&v.stake)?);
+            }
+            for v in &validator_response.current_validators {
+                result.insert(parse_account_id(&v.account_id)?, parse_near_token(&v.stake)?);
+            }
+            for v in &validator_response.next_validators {
+                result.insert(parse_account_id(&v.account_id)?, parse_near_token(&v.stake)?);
+            }
+            Ok(result)
         })
     }
 
@@ -732,14 +733,13 @@ pub struct ActiveStakingPoolQuery;
 impl RpcType for ActiveStakingPoolQuery {
     type RpcReference = <SimpleQueryRpc as RpcType>::RpcReference;
     type Response = <SimpleQueryRpc as RpcType>::Response;
-    type Error = <SimpleQueryRpc as RpcType>::Error;
 
     async fn send_query(
         &self,
-        client: &near_openapi_client::Client,
+        client: &RpcClient,
         network: &NetworkConfig,
         reference: &Reference,
-    ) -> RetryResponse<RpcQueryResponse, SendRequestError<RpcQueryError>> {
+    ) -> RetryResponse<serde_json::Value, SendRequestError> {
         let Some(account_id) = network.staking_pools_factory_account_id.clone() else {
             return RetryResponse::Critical(SendRequestError::RequestCreationError(
                 QueryCreationError::StakingPoolFactoryNotDefined,
@@ -768,8 +768,8 @@ impl ResponseHandler for ActiveStakingHandler {
 
     fn process_response(
         &self,
-        response: Vec<RpcQueryResponse>,
-    ) -> core::result::Result<Self::Response, QueryError<RpcQueryError>> {
+        response: Vec<serde_json::Value>,
+    ) -> core::result::Result<Self::Response, QueryError> {
         let query_result = ViewStateHandler {}.process_response(response)?;
 
         Ok(query_result

--- a/api/tests/regression.rs
+++ b/api/tests/regression.rs
@@ -12,10 +12,10 @@ async fn regression_85() -> testresult::TestResult {
         .await
         .expect_err("Should fail as the contract is not deployed");
 
-    // Should be a WASM execution error rather than TransportError(Invalid Response Payload
+    // Should be a server error (HANDLER_ERROR) rather than TransportError(Invalid Response Payload)
     let query_error = match contract {
         near_api::errors::QueryError::QueryError(query) => query,
-        _ => panic!("Should be a QueryError"),
+        _ => panic!("Should be a QueryError, got: {contract:?}"),
     };
 
     let retry_error = match *query_error {
@@ -23,10 +23,13 @@ async fn regression_85() -> testresult::TestResult {
         _ => panic!("Should be a RetryError"),
     };
 
-    assert!(matches!(
-        retry_error,
-        near_api::errors::SendRequestError::WasmExecutionError(_)
-    ));
+    assert!(
+        matches!(
+            retry_error,
+            near_api::errors::SendRequestError::ServerError(ref err) if err.is_handler_error()
+        ),
+        "Expected ServerError with HANDLER_ERROR, got: {retry_error:?}"
+    );
 
     Ok(())
 }

--- a/api/tests/regression.rs
+++ b/api/tests/regression.rs
@@ -23,12 +23,20 @@ async fn regression_85() -> testresult::TestResult {
         _ => panic!("Should be a RetryError"),
     };
 
+    // With the openrpc client, contract execution errors from `query` are returned as
+    // ContractExecutionError (extracted from the result JSON `error` field) rather than
+    // ServerError(HANDLER_ERROR). Both represent a properly parsed error rather than a
+    // transport/deserialization failure, which is what issue #85 was about.
+    let is_expected = matches!(
+        &retry_error,
+        near_api::errors::SendRequestError::ContractExecutionError(_)
+    ) || matches!(
+        &retry_error,
+        near_api::errors::SendRequestError::ServerError(err) if err.is_handler_error()
+    );
     assert!(
-        matches!(
-            retry_error,
-            near_api::errors::SendRequestError::ServerError(ref err) if err.is_handler_error()
-        ),
-        "Expected ServerError with HANDLER_ERROR, got: {retry_error:?}"
+        is_expected,
+        "Expected ContractExecutionError or ServerError with HANDLER_ERROR, got: {retry_error:?}"
     );
 
     Ok(())

--- a/cspell.json
+++ b/cspell.json
@@ -66,7 +66,8 @@
         "SECP",
         "chrono",
         "testresult",
-        "btreemap"
+        "btreemap",
+        "openrpc"
     ],
     "ignoreRegExpList": [
         // Base58 encoded public key/secret key

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -18,7 +18,7 @@ base64.workspace = true
 sha2.workspace = true
 serde_with.workspace = true
 
-near-openapi-types.workspace = true
+near-openrpc-client.workspace = true
 near-account-id.workspace = true
 near-gas.workspace = true
 near-token.workspace = true

--- a/types/src/account.rs
+++ b/types/src/account.rs
@@ -38,12 +38,14 @@ pub struct Account {
     pub storage_usage: StorageUsage,
 }
 
-impl TryFrom<near_openapi_types::AccountView> for Account {
+impl TryFrom<near_openrpc_client::RpcViewAccountResponse> for Account {
     type Error = DataConversionError;
 
-    fn try_from(value: near_openapi_types::AccountView) -> Result<Self, Self::Error> {
-        let near_openapi_types::AccountView {
+    fn try_from(value: near_openrpc_client::RpcViewAccountResponse) -> Result<Self, Self::Error> {
+        let near_openrpc_client::RpcViewAccountResponse {
             amount,
+            block_hash: _,
+            block_height: _,
             code_hash,
             global_contract_account_id,
             global_contract_hash,
@@ -52,10 +54,19 @@ impl TryFrom<near_openapi_types::AccountView> for Account {
             storage_usage,
         } = value;
 
-        let code_hash = CryptoHash::from(code_hash);
+        let amount = NearToken::from_yoctonear(amount.parse::<u128>()?);
+        let locked = NearToken::from_yoctonear(locked.parse::<u128>()?);
+        let code_hash = CryptoHash::try_from(code_hash)?;
+
+        let global_contract_hash = global_contract_hash
+            .map(CryptoHash::try_from)
+            .transpose()?;
+        let global_contract_account_id: Option<AccountId> = global_contract_account_id
+            .map(|id| id.parse::<AccountId>())
+            .transpose()?;
 
         let contract_state = match (code_hash, global_contract_account_id, global_contract_hash) {
-            (_, _, Some(hash)) => ContractState::from_global_contract_hash(hash.into()),
+            (_, _, Some(hash)) => ContractState::from_global_contract_hash(hash),
             (_, Some(account_id), _) => account_id.into(),
             (hash, _, _) if hash == CryptoHash::default() => ContractState::None,
             (hash, _, _) => ContractState::from_local_hash(hash),

--- a/types/src/account.rs
+++ b/types/src/account.rs
@@ -58,9 +58,7 @@ impl TryFrom<near_openrpc_client::RpcViewAccountResponse> for Account {
         let locked = NearToken::from_yoctonear(locked.parse::<u128>()?);
         let code_hash = CryptoHash::try_from(code_hash)?;
 
-        let global_contract_hash = global_contract_hash
-            .map(CryptoHash::try_from)
-            .transpose()?;
+        let global_contract_hash = global_contract_hash.map(CryptoHash::try_from).transpose()?;
         let global_contract_account_id: Option<AccountId> = global_contract_account_id
             .map(|id| id.parse::<AccountId>())
             .transpose()?;

--- a/types/src/crypto/public_key.rs
+++ b/types/src/crypto/public_key.rs
@@ -71,14 +71,14 @@ impl PublicKey {
     }
 }
 
-impl TryFrom<near_openapi_types::PublicKey> for PublicKey {
+impl TryFrom<near_openrpc_client::PublicKey> for PublicKey {
     type Error = DataConversionError;
-    fn try_from(val: near_openapi_types::PublicKey) -> Result<Self, Self::Error> {
-        Self::from_str(&val.0)
+    fn try_from(val: near_openrpc_client::PublicKey) -> Result<Self, Self::Error> {
+        Self::from_str(&val)
     }
 }
 
-impl From<PublicKey> for near_openapi_types::PublicKey {
+impl From<PublicKey> for near_openrpc_client::PublicKey {
     fn from(val: PublicKey) -> Self {
         Self(val.to_string())
     }

--- a/types/src/errors.rs
+++ b/types/src/errors.rs
@@ -1,6 +1,6 @@
 use std::array::TryFromSliceError;
 
-use near_openapi_types::TxExecutionError;
+use near_openrpc_client::TxExecutionError;
 
 use crate::transaction::result::ExecutionFailure;
 
@@ -48,6 +48,8 @@ pub enum DataConversionError {
     DelegateActionNotSupported,
     #[error("Invalid global contract identifier")]
     InvalidGlobalContractIdentifier,
+    #[error("Invalid account ID: {0}")]
+    InvalidAccountId(#[from] near_account_id::ParseAccountError),
 }
 
 impl From<Vec<u8>> for DataConversionError {

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -23,10 +23,9 @@ pub use near_abi as abi;
 pub use near_account_id::AccountId;
 pub use near_gas::NearGas;
 pub use near_openrpc_client::{
-    FunctionArgs, RpcBlockResponse, RpcCallFunctionResponse,
-    RpcLightClientExecutionProofResponse, RpcReceiptResponse, RpcTransactionResponse,
-    RpcValidatorResponse, RpcViewAccountResponse, RpcViewCodeResponse, RpcViewStateResponse,
-    StateItem, StoreKey, StoreValue, TxExecutionStatus,
+    FunctionArgs, RpcBlockResponse, RpcCallFunctionResponse, RpcLightClientExecutionProofResponse,
+    RpcReceiptResponse, RpcTransactionResponse, RpcValidatorResponse, RpcViewAccountResponse,
+    RpcViewCodeResponse, RpcViewStateResponse, StateItem, StoreKey, StoreValue, TxExecutionStatus,
 };
 pub use near_token::NearToken;
 pub use reference::{EpochReference, Reference};

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -1,6 +1,8 @@
+use std::fmt;
+use std::str::FromStr;
+
 use secp256k1::ThirtyTwoByteHash;
 use sha2::Digest;
-use std::fmt;
 
 pub mod account;
 pub mod contract;
@@ -20,9 +22,10 @@ pub mod utils;
 pub use near_abi as abi;
 pub use near_account_id::AccountId;
 pub use near_gas::NearGas;
-pub use near_openapi_types::{
-    AccountView, ContractCodeView, FunctionArgs, RpcBlockResponse, RpcTransactionResponse,
-    RpcValidatorResponse, StoreKey, StoreValue, TxExecutionStatus, ViewStateResult,
+pub use near_openrpc_client::{
+    FunctionArgs, RpcBlockResponse, RpcCallFunctionResponse, RpcTransactionResponse,
+    RpcValidatorResponse, RpcViewAccountResponse, RpcViewCodeResponse, RpcViewStateResponse,
+    StateItem, StoreKey, StoreValue, TxExecutionStatus,
 };
 pub use near_token::NearToken;
 pub use reference::{EpochReference, Reference};
@@ -148,9 +151,11 @@ impl TryFrom<Vec<u8>> for CryptoHash {
     }
 }
 
-impl From<near_openapi_types::CryptoHash> for CryptoHash {
-    fn from(value: near_openapi_types::CryptoHash) -> Self {
-        Self(value.0)
+impl TryFrom<near_openrpc_client::CryptoHash> for CryptoHash {
+    type Error = DataConversionError;
+
+    fn try_from(value: near_openrpc_client::CryptoHash) -> Result<Self, Self::Error> {
+        Self::from_str(&value)
     }
 }
 
@@ -166,8 +171,8 @@ impl std::fmt::Display for CryptoHash {
     }
 }
 
-impl From<CryptoHash> for near_openapi_types::CryptoHash {
+impl From<CryptoHash> for near_openrpc_client::CryptoHash {
     fn from(hash: CryptoHash) -> Self {
-        Self(hash.0)
+        Self(hash.to_string())
     }
 }

--- a/types/src/transaction/actions.rs
+++ b/types/src/transaction/actions.rs
@@ -14,6 +14,10 @@ use crate::transaction::delegate_action::SignedDelegateAction;
 use crate::utils::near_gas_as_u64;
 use crate::{CryptoHash, NearGas, NearToken, PublicKey, Signature};
 
+pub(crate) fn parse_near_token(s: &str) -> Result<NearToken, DataConversionError> {
+    Ok(NearToken::from_yoctonear(s.parse::<u128>()?))
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub enum Action {
     /// Create an (sub)account using a transaction `receiver_id` as an ID for
@@ -81,20 +85,22 @@ pub struct DeterministicAccountStateInitV1 {
     pub data: BTreeMap<Vec<u8>, Vec<u8>>,
 }
 
-impl TryFrom<near_openapi_types::DeterministicStateInitAction> for DeterministicStateInitAction {
+impl TryFrom<near_openrpc_client::DeterministicStateInitAction> for DeterministicStateInitAction {
     type Error = DataConversionError;
     fn try_from(
-        val: near_openapi_types::DeterministicStateInitAction,
+        val: near_openrpc_client::DeterministicStateInitAction,
     ) -> Result<Self, Self::Error> {
-        let near_openapi_types::DeterministicStateInitAction {
+        let near_openrpc_client::DeterministicStateInitAction {
             state_init,
             deposit,
         } = val;
 
+        let deposit = parse_near_token(&deposit)?;
+
         match state_init {
-            near_openapi_types::DeterministicAccountStateInit::V1(v1) => Ok(Self {
+            near_openrpc_client::DeterministicAccountStateInit::V1(v1) => Ok(Self {
                 state_init: DeterministicAccountStateInit::V1(DeterministicAccountStateInitV1 {
-                    code: v1.code.into(),
+                    code: v1.code.try_into()?,
                     data: v1
                         .data
                         .into_iter()
@@ -120,10 +126,10 @@ pub struct DeployGlobalContractAction {
     pub deploy_mode: GlobalContractDeployMode,
 }
 
-impl TryFrom<near_openapi_types::DeployGlobalContractAction> for DeployGlobalContractAction {
+impl TryFrom<near_openrpc_client::DeployGlobalContractAction> for DeployGlobalContractAction {
     type Error = DataConversionError;
-    fn try_from(val: near_openapi_types::DeployGlobalContractAction) -> Result<Self, Self::Error> {
-        let near_openapi_types::DeployGlobalContractAction { code, deploy_mode } = val;
+    fn try_from(val: near_openrpc_client::DeployGlobalContractAction) -> Result<Self, Self::Error> {
+        let near_openrpc_client::DeployGlobalContractAction { code, deploy_mode } = val;
         Ok(Self {
             code: BASE64_STANDARD.decode(code)?,
             deploy_mode: deploy_mode.into(),
@@ -135,22 +141,23 @@ pub struct UseGlobalContractAction {
     pub contract_identifier: GlobalContractIdentifier,
 }
 
-impl From<near_openapi_types::UseGlobalContractAction> for UseGlobalContractAction {
-    fn from(val: near_openapi_types::UseGlobalContractAction) -> Self {
-        let near_openapi_types::UseGlobalContractAction {
+impl TryFrom<near_openrpc_client::UseGlobalContractAction> for UseGlobalContractAction {
+    type Error = DataConversionError;
+    fn try_from(val: near_openrpc_client::UseGlobalContractAction) -> Result<Self, Self::Error> {
+        let near_openrpc_client::UseGlobalContractAction {
             contract_identifier,
         } = val;
-        Self {
-            contract_identifier: contract_identifier.into(),
-        }
+        Ok(Self {
+            contract_identifier: contract_identifier.try_into()?,
+        })
     }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct CreateAccountAction {}
 
-impl From<near_openapi_types::CreateAccountAction> for CreateAccountAction {
-    fn from(_: near_openapi_types::CreateAccountAction) -> Self {
+impl From<near_openrpc_client::CreateAccountAction> for CreateAccountAction {
+    fn from(_val: near_openrpc_client::CreateAccountAction) -> Self {
         Self {}
     }
 }
@@ -162,10 +169,10 @@ pub struct DeployContractAction {
     pub code: Vec<u8>,
 }
 
-impl TryFrom<near_openapi_types::DeployContractAction> for DeployContractAction {
+impl TryFrom<near_openrpc_client::DeployContractAction> for DeployContractAction {
     type Error = DataConversionError;
-    fn try_from(val: near_openapi_types::DeployContractAction) -> Result<Self, Self::Error> {
-        let near_openapi_types::DeployContractAction { code } = val;
+    fn try_from(val: near_openrpc_client::DeployContractAction) -> Result<Self, Self::Error> {
+        let near_openrpc_client::DeployContractAction { code } = val;
         Ok(Self {
             code: BASE64_STANDARD.decode(code)?,
         })
@@ -183,10 +190,10 @@ pub struct FunctionCallAction {
     pub deposit: NearToken,
 }
 
-impl TryFrom<near_openapi_types::FunctionCallAction> for FunctionCallAction {
+impl TryFrom<near_openrpc_client::FunctionCallAction> for FunctionCallAction {
     type Error = DataConversionError;
-    fn try_from(val: near_openapi_types::FunctionCallAction) -> Result<Self, Self::Error> {
-        let near_openapi_types::FunctionCallAction {
+    fn try_from(val: near_openrpc_client::FunctionCallAction) -> Result<Self, Self::Error> {
+        let near_openrpc_client::FunctionCallAction {
             method_name,
             args,
             gas,
@@ -194,9 +201,9 @@ impl TryFrom<near_openapi_types::FunctionCallAction> for FunctionCallAction {
         } = val;
         Ok(Self {
             method_name,
-            args: BASE64_STANDARD.decode(args)?,
-            gas,
-            deposit,
+            args: BASE64_STANDARD.decode(&*args)?,
+            gas: NearGas::from_gas(*gas),
+            deposit: parse_near_token(&deposit)?,
         })
     }
 }
@@ -206,11 +213,13 @@ pub struct TransferAction {
     pub deposit: NearToken,
 }
 
-impl TryFrom<near_openapi_types::TransferAction> for TransferAction {
+impl TryFrom<near_openrpc_client::TransferAction> for TransferAction {
     type Error = DataConversionError;
-    fn try_from(val: near_openapi_types::TransferAction) -> Result<Self, Self::Error> {
-        let near_openapi_types::TransferAction { deposit } = val;
-        Ok(Self { deposit })
+    fn try_from(val: near_openrpc_client::TransferAction) -> Result<Self, Self::Error> {
+        let near_openrpc_client::TransferAction { deposit } = val;
+        Ok(Self {
+            deposit: parse_near_token(&deposit)?,
+        })
     }
 }
 
@@ -222,13 +231,13 @@ pub struct StakeAction {
     pub public_key: PublicKey,
 }
 
-impl TryFrom<near_openapi_types::StakeAction> for StakeAction {
+impl TryFrom<near_openrpc_client::StakeAction> for StakeAction {
     type Error = DataConversionError;
-    fn try_from(val: near_openapi_types::StakeAction) -> Result<Self, Self::Error> {
-        let near_openapi_types::StakeAction { public_key, stake } = val;
+    fn try_from(val: near_openrpc_client::StakeAction) -> Result<Self, Self::Error> {
+        let near_openrpc_client::StakeAction { public_key, stake } = val;
         Ok(Self {
             public_key: public_key.try_into()?,
-            stake,
+            stake: parse_near_token(&stake)?,
         })
     }
 }
@@ -240,36 +249,12 @@ pub struct AddGasKeyAction {
     pub permission: AccessKeyPermission,
 }
 
-impl TryFrom<near_openapi_types::AddGasKeyAction> for AddGasKeyAction {
-    type Error = DataConversionError;
-    fn try_from(val: near_openapi_types::AddGasKeyAction) -> Result<Self, Self::Error> {
-        let near_openapi_types::AddGasKeyAction {
-            public_key,
-            num_nonces,
-            permission,
-        } = val;
-        Ok(Self {
-            public_key: public_key.try_into()?,
-            num_nonces,
-            permission: permission.try_into()?,
-        })
-    }
-}
 
 #[derive(Serialize, Deserialize, Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct DeleteGasKeyAction {
     pub public_key: PublicKey,
 }
 
-impl TryFrom<near_openapi_types::DeleteGasKeyAction> for DeleteGasKeyAction {
-    type Error = DataConversionError;
-    fn try_from(val: near_openapi_types::DeleteGasKeyAction) -> Result<Self, Self::Error> {
-        let near_openapi_types::DeleteGasKeyAction { public_key } = val;
-        Ok(Self {
-            public_key: public_key.try_into()?,
-        })
-    }
-}
 
 #[derive(Serialize, Deserialize, Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct TransferToGasKeyAction {
@@ -277,16 +262,16 @@ pub struct TransferToGasKeyAction {
     pub deposit: NearToken,
 }
 
-impl TryFrom<near_openapi_types::TransferToGasKeyAction> for TransferToGasKeyAction {
+impl TryFrom<near_openrpc_client::TransferToGasKeyAction> for TransferToGasKeyAction {
     type Error = DataConversionError;
-    fn try_from(val: near_openapi_types::TransferToGasKeyAction) -> Result<Self, Self::Error> {
-        let near_openapi_types::TransferToGasKeyAction {
+    fn try_from(val: near_openrpc_client::TransferToGasKeyAction) -> Result<Self, Self::Error> {
+        let near_openrpc_client::TransferToGasKeyAction {
             public_key,
             deposit,
         } = val;
         Ok(Self {
             public_key: public_key.try_into()?,
-            deposit,
+            deposit: parse_near_token(&deposit)?,
         })
     }
 }
@@ -299,10 +284,10 @@ pub struct AddKeyAction {
     pub access_key: AccessKey,
 }
 
-impl TryFrom<near_openapi_types::AddKeyAction> for AddKeyAction {
+impl TryFrom<near_openrpc_client::AddKeyAction> for AddKeyAction {
     type Error = DataConversionError;
-    fn try_from(val: near_openapi_types::AddKeyAction) -> Result<Self, Self::Error> {
-        let near_openapi_types::AddKeyAction {
+    fn try_from(val: near_openrpc_client::AddKeyAction) -> Result<Self, Self::Error> {
+        let near_openrpc_client::AddKeyAction {
             public_key,
             access_key,
         } = val;
@@ -323,10 +308,10 @@ pub struct AccessKey {
     pub permission: AccessKeyPermission,
 }
 
-impl TryFrom<near_openapi_types::AccessKeyView> for AccessKey {
+impl TryFrom<near_openrpc_client::AccessKeyView> for AccessKey {
     type Error = DataConversionError;
-    fn try_from(val: near_openapi_types::AccessKeyView) -> Result<Self, Self::Error> {
-        let near_openapi_types::AccessKeyView { nonce, permission } = val;
+    fn try_from(val: near_openrpc_client::AccessKeyView) -> Result<Self, Self::Error> {
+        let near_openrpc_client::AccessKeyView { nonce, permission } = val;
         Ok(Self {
             nonce: U64(nonce),
             permission: permission.try_into()?,
@@ -334,10 +319,10 @@ impl TryFrom<near_openapi_types::AccessKeyView> for AccessKey {
     }
 }
 
-impl TryFrom<near_openapi_types::AccessKey> for AccessKey {
+impl TryFrom<near_openrpc_client::AccessKey> for AccessKey {
     type Error = DataConversionError;
-    fn try_from(val: near_openapi_types::AccessKey) -> Result<Self, Self::Error> {
-        let near_openapi_types::AccessKey { nonce, permission } = val;
+    fn try_from(val: near_openrpc_client::AccessKey) -> Result<Self, Self::Error> {
+        let near_openrpc_client::AccessKey { nonce, permission } = val;
         Ok(Self {
             nonce: U64(nonce),
             permission: permission.try_into()?,
@@ -353,32 +338,40 @@ pub enum AccessKeyPermission {
     FullAccess,
 }
 
-impl TryFrom<near_openapi_types::AccessKeyPermissionView> for AccessKeyPermission {
+impl TryFrom<near_openrpc_client::AccessKeyPermissionView> for AccessKeyPermission {
     type Error = DataConversionError;
-    fn try_from(val: near_openapi_types::AccessKeyPermissionView) -> Result<Self, Self::Error> {
+    fn try_from(val: near_openrpc_client::AccessKeyPermissionView) -> Result<Self, Self::Error> {
         match val {
-            near_openapi_types::AccessKeyPermissionView::FunctionCall {
+            near_openrpc_client::AccessKeyPermissionView::FunctionCall {
                 allowance,
                 method_names,
                 receiver_id,
             } => Ok(Self::FunctionCall(FunctionCallPermission {
-                allowance,
+                allowance: allowance.map(|a| parse_near_token(&a)).transpose()?,
                 receiver_id,
                 method_names,
             })),
-            near_openapi_types::AccessKeyPermissionView::FullAccess => Ok(Self::FullAccess),
+            near_openrpc_client::AccessKeyPermissionView::FullAccess => Ok(Self::FullAccess),
+            near_openrpc_client::AccessKeyPermissionView::GasKeyFunctionCall { .. }
+            | near_openrpc_client::AccessKeyPermissionView::GasKeyFullAccess { .. } => {
+                Ok(Self::FullAccess)
+            }
         }
     }
 }
 
-impl TryFrom<near_openapi_types::AccessKeyPermission> for AccessKeyPermission {
+impl TryFrom<near_openrpc_client::AccessKeyPermission> for AccessKeyPermission {
     type Error = DataConversionError;
-    fn try_from(val: near_openapi_types::AccessKeyPermission) -> Result<Self, Self::Error> {
+    fn try_from(val: near_openrpc_client::AccessKeyPermission) -> Result<Self, Self::Error> {
         match val {
-            near_openapi_types::AccessKeyPermission::FunctionCall(function_call_permission) => {
+            near_openrpc_client::AccessKeyPermission::FunctionCall(function_call_permission) => {
                 Ok(Self::FunctionCall(function_call_permission.try_into()?))
             }
-            near_openapi_types::AccessKeyPermission::FullAccess => Ok(Self::FullAccess),
+            near_openrpc_client::AccessKeyPermission::FullAccess => Ok(Self::FullAccess),
+            near_openrpc_client::AccessKeyPermission::GasKeyFunctionCall(_, function_call_permission) => {
+                Ok(Self::FunctionCall(function_call_permission.try_into()?))
+            }
+            near_openrpc_client::AccessKeyPermission::GasKeyFullAccess(_) => Ok(Self::FullAccess),
         }
     }
 }
@@ -390,16 +383,16 @@ pub struct FunctionCallPermission {
     pub method_names: Vec<String>,
 }
 
-impl TryFrom<near_openapi_types::FunctionCallPermission> for FunctionCallPermission {
+impl TryFrom<near_openrpc_client::FunctionCallPermission> for FunctionCallPermission {
     type Error = DataConversionError;
-    fn try_from(val: near_openapi_types::FunctionCallPermission) -> Result<Self, Self::Error> {
-        let near_openapi_types::FunctionCallPermission {
+    fn try_from(val: near_openrpc_client::FunctionCallPermission) -> Result<Self, Self::Error> {
+        let near_openrpc_client::FunctionCallPermission {
             allowance,
             receiver_id,
             method_names,
         } = val;
         Ok(Self {
-            allowance,
+            allowance: allowance.map(|a| parse_near_token(&a)).transpose()?,
             receiver_id,
             method_names,
         })
@@ -412,10 +405,10 @@ pub struct DeleteKeyAction {
     pub public_key: PublicKey,
 }
 
-impl TryFrom<near_openapi_types::DeleteKeyAction> for DeleteKeyAction {
+impl TryFrom<near_openrpc_client::DeleteKeyAction> for DeleteKeyAction {
     type Error = DataConversionError;
-    fn try_from(val: near_openapi_types::DeleteKeyAction) -> Result<Self, Self::Error> {
-        let near_openapi_types::DeleteKeyAction { public_key } = val;
+    fn try_from(val: near_openrpc_client::DeleteKeyAction) -> Result<Self, Self::Error> {
+        let near_openrpc_client::DeleteKeyAction { public_key } = val;
         Ok(Self {
             public_key: public_key.try_into()?,
         })
@@ -427,10 +420,13 @@ pub struct DeleteAccountAction {
     pub beneficiary_id: AccountId,
 }
 
-impl From<near_openapi_types::DeleteAccountAction> for DeleteAccountAction {
-    fn from(val: near_openapi_types::DeleteAccountAction) -> Self {
-        let near_openapi_types::DeleteAccountAction { beneficiary_id } = val;
-        Self { beneficiary_id }
+impl TryFrom<near_openrpc_client::DeleteAccountAction> for DeleteAccountAction {
+    type Error = DataConversionError;
+    fn try_from(val: near_openrpc_client::DeleteAccountAction) -> Result<Self, Self::Error> {
+        let near_openrpc_client::DeleteAccountAction { beneficiary_id } = val;
+        Ok(Self {
+            beneficiary_id: beneficiary_id.parse()?,
+        })
     }
 }
 
@@ -456,11 +452,11 @@ pub enum GlobalContractDeployMode {
     AccountId,
 }
 
-impl From<near_openapi_types::GlobalContractDeployMode> for GlobalContractDeployMode {
-    fn from(val: near_openapi_types::GlobalContractDeployMode) -> Self {
+impl From<near_openrpc_client::GlobalContractDeployMode> for GlobalContractDeployMode {
+    fn from(val: near_openrpc_client::GlobalContractDeployMode) -> Self {
         match val {
-            near_openapi_types::GlobalContractDeployMode::CodeHash => Self::CodeHash,
-            near_openapi_types::GlobalContractDeployMode::AccountId => Self::AccountId,
+            near_openrpc_client::GlobalContractDeployMode::CodeHash => Self::CodeHash,
+            near_openrpc_client::GlobalContractDeployMode::AccountId => Self::AccountId,
         }
     }
 }
@@ -470,37 +466,39 @@ pub enum GlobalContractIdentifier {
     AccountId(AccountId),
 }
 
-impl From<near_openapi_types::GlobalContractIdentifier> for GlobalContractIdentifier {
-    fn from(val: near_openapi_types::GlobalContractIdentifier) -> Self {
-        match val {
-            near_openapi_types::GlobalContractIdentifier::CodeHash(code_hash) => {
-                Self::CodeHash(code_hash.into())
-            }
-            near_openapi_types::GlobalContractIdentifier::AccountId(account_id) => {
-                Self::AccountId(account_id)
-            }
-        }
-    }
-}
-
-impl From<near_openapi_types::GlobalContractIdentifierView> for GlobalContractIdentifier {
-    fn from(val: near_openapi_types::GlobalContractIdentifierView) -> Self {
-        match val {
-            near_openapi_types::GlobalContractIdentifierView::CryptoHash(code_hash) => {
-                Self::CodeHash(code_hash.into())
-            }
-            near_openapi_types::GlobalContractIdentifierView::AccountId(account_id) => {
-                Self::AccountId(account_id)
-            }
-        }
-    }
-}
-
-impl TryFrom<near_openapi_types::ActionView> for Action {
+impl TryFrom<near_openrpc_client::GlobalContractIdentifier> for GlobalContractIdentifier {
     type Error = DataConversionError;
-    fn try_from(val: near_openapi_types::ActionView) -> Result<Self, Self::Error> {
+    fn try_from(val: near_openrpc_client::GlobalContractIdentifier) -> Result<Self, Self::Error> {
         match val {
-            near_openapi_types::ActionView::DeterministicStateInit {
+            near_openrpc_client::GlobalContractIdentifier::CodeHash(code_hash) => {
+                Ok(Self::CodeHash(code_hash.try_into()?))
+            }
+            near_openrpc_client::GlobalContractIdentifier::AccountId(account_id) => {
+                Ok(Self::AccountId(account_id.parse()?))
+            }
+        }
+    }
+}
+
+impl TryFrom<near_openrpc_client::GlobalContractIdentifierView> for GlobalContractIdentifier {
+    type Error = DataConversionError;
+    fn try_from(val: near_openrpc_client::GlobalContractIdentifierView) -> Result<Self, Self::Error> {
+        match val {
+            near_openrpc_client::GlobalContractIdentifierView::Hash(code_hash) => {
+                Ok(Self::CodeHash(code_hash.try_into()?))
+            }
+            near_openrpc_client::GlobalContractIdentifierView::AccountId(account_id) => {
+                Ok(Self::AccountId(account_id.parse()?))
+            }
+        }
+    }
+}
+
+impl TryFrom<near_openrpc_client::ActionView> for Action {
+    type Error = DataConversionError;
+    fn try_from(val: near_openrpc_client::ActionView) -> Result<Self, Self::Error> {
+        match val {
+            near_openrpc_client::ActionView::DeterministicStateInit {
                 code,
                 data,
                 deposit,
@@ -508,7 +506,7 @@ impl TryFrom<near_openapi_types::ActionView> for Action {
                 DeterministicStateInitAction {
                     state_init: DeterministicAccountStateInit::V1(
                         DeterministicAccountStateInitV1 {
-                            code: code.into(),
+                            code: code.try_into()?,
                             data: data
                                 .into_iter()
                                 .map(|(k, v)| {
@@ -520,101 +518,98 @@ impl TryFrom<near_openapi_types::ActionView> for Action {
                                 .collect::<Result<BTreeMap<Vec<u8>, Vec<u8>>, _>>()?,
                         },
                     ),
-                    deposit,
+                    deposit: parse_near_token(&deposit)?,
                 },
             ))),
-            near_openapi_types::ActionView::CreateAccount => {
+            near_openrpc_client::ActionView::CreateAccount => {
                 Ok(Self::CreateAccount(CreateAccountAction {}))
             }
-            near_openapi_types::ActionView::DeployContract { code } => {
+            near_openrpc_client::ActionView::DeployContract { code } => {
                 Ok(Self::DeployContract(DeployContractAction {
                     code: BASE64_STANDARD.decode(code)?,
                 }))
             }
-            near_openapi_types::ActionView::FunctionCall {
+            near_openrpc_client::ActionView::FunctionCall {
                 method_name,
                 args,
                 gas,
                 deposit,
             } => Ok(Self::FunctionCall(Box::new(FunctionCallAction {
                 method_name,
-                args: BASE64_STANDARD.decode(args.0)?,
-                gas,
-                deposit,
+                args: BASE64_STANDARD.decode(&*args)?,
+                gas: NearGas::from_gas(*gas),
+                deposit: parse_near_token(&deposit)?,
             }))),
-            near_openapi_types::ActionView::Transfer { deposit } => {
-                Ok(Self::Transfer(TransferAction { deposit }))
+            near_openrpc_client::ActionView::Transfer { deposit } => {
+                Ok(Self::Transfer(TransferAction {
+                    deposit: parse_near_token(&deposit)?,
+                }))
             }
-            near_openapi_types::ActionView::Stake { public_key, stake } => {
+            near_openrpc_client::ActionView::Stake { public_key, stake } => {
                 Ok(Self::Stake(Box::new(StakeAction {
                     public_key: public_key.try_into()?,
-                    stake,
+                    stake: parse_near_token(&stake)?,
                 })))
             }
-            near_openapi_types::ActionView::AddKey {
+            near_openrpc_client::ActionView::AddKey {
                 access_key,
                 public_key,
             } => Ok(Self::AddKey(Box::new(AddKeyAction {
                 public_key: public_key.try_into()?,
                 access_key: access_key.try_into()?,
             }))),
-            near_openapi_types::ActionView::DeleteKey { public_key } => {
+            near_openrpc_client::ActionView::DeleteKey { public_key } => {
                 Ok(Self::DeleteKey(Box::new(DeleteKeyAction {
                     public_key: public_key.try_into()?,
                 })))
             }
-            near_openapi_types::ActionView::DeleteAccount { beneficiary_id } => {
-                Ok(Self::DeleteAccount(DeleteAccountAction { beneficiary_id }))
+            near_openrpc_client::ActionView::DeleteAccount { beneficiary_id } => {
+                Ok(Self::DeleteAccount(DeleteAccountAction {
+                    beneficiary_id: beneficiary_id.parse()?,
+                }))
             }
-            near_openapi_types::ActionView::Delegate {
+            near_openrpc_client::ActionView::Delegate {
                 delegate_action,
                 signature,
             } => Ok(Self::Delegate(Box::new(SignedDelegateAction {
                 delegate_action: delegate_action.try_into()?,
                 signature: Signature::from_str(&signature)?,
             }))),
-            near_openapi_types::ActionView::DeployGlobalContract { code } => {
+            near_openrpc_client::ActionView::DeployGlobalContract { code } => {
                 Ok(Self::DeployGlobalContract(DeployGlobalContractAction {
                     code: BASE64_STANDARD.decode(code)?,
                     deploy_mode: GlobalContractDeployMode::CodeHash,
                 }))
             }
-            near_openapi_types::ActionView::DeployGlobalContractByAccountId { code } => {
+            near_openrpc_client::ActionView::DeployGlobalContractByAccountId { code } => {
                 Ok(Self::DeployGlobalContract(DeployGlobalContractAction {
                     code: BASE64_STANDARD.decode(code)?,
                     deploy_mode: GlobalContractDeployMode::AccountId,
                 }))
             }
-            near_openapi_types::ActionView::UseGlobalContract { code_hash } => {
+            near_openrpc_client::ActionView::UseGlobalContract { code_hash } => {
                 Ok(Self::UseGlobalContract(Box::new(UseGlobalContractAction {
-                    contract_identifier: GlobalContractIdentifier::CodeHash(code_hash.into()),
+                    contract_identifier: GlobalContractIdentifier::CodeHash(code_hash.try_into()?),
                 })))
             }
-            near_openapi_types::ActionView::UseGlobalContractByAccountId { account_id } => {
+            near_openrpc_client::ActionView::UseGlobalContractByAccountId { account_id } => {
                 Ok(Self::UseGlobalContract(Box::new(UseGlobalContractAction {
-                    contract_identifier: GlobalContractIdentifier::AccountId(account_id),
+                    contract_identifier: GlobalContractIdentifier::AccountId(account_id.parse()?),
                 })))
             }
-            near_openapi_types::ActionView::AddGasKey {
-                num_nonces,
-                permission,
-                public_key,
-            } => Ok(Self::AddGasKey(Box::new(AddGasKeyAction {
-                public_key: public_key.try_into()?,
-                num_nonces,
-                permission: permission.try_into()?,
-            }))),
-            near_openapi_types::ActionView::DeleteGasKey { public_key } => {
-                Ok(Self::DeleteGasKey(Box::new(DeleteGasKeyAction {
-                    public_key: public_key.try_into()?,
-                })))
-            }
-            near_openapi_types::ActionView::TransferToGasKey {
-                amount: deposit,
+            near_openrpc_client::ActionView::TransferToGasKey {
+                deposit,
                 public_key,
             } => Ok(Self::TransferToGasKey(Box::new(TransferToGasKeyAction {
                 public_key: public_key.try_into()?,
-                deposit,
+                deposit: parse_near_token(&deposit)?,
+            }))),
+            near_openrpc_client::ActionView::WithdrawFromGasKey {
+                amount,
+                public_key,
+            } => Ok(Self::TransferToGasKey(Box::new(TransferToGasKeyAction {
+                public_key: public_key.try_into()?,
+                deposit: parse_near_token(&amount)?,
             }))),
         }
     }

--- a/types/src/transaction/actions.rs
+++ b/types/src/transaction/actions.rs
@@ -350,8 +350,17 @@ impl TryFrom<near_openrpc_client::AccessKeyPermissionView> for AccessKeyPermissi
                 method_names,
             })),
             near_openrpc_client::AccessKeyPermissionView::FullAccess => Ok(Self::FullAccess),
-            near_openrpc_client::AccessKeyPermissionView::GasKeyFunctionCall { .. }
-            | near_openrpc_client::AccessKeyPermissionView::GasKeyFullAccess { .. } => {
+            near_openrpc_client::AccessKeyPermissionView::GasKeyFunctionCall {
+                allowance,
+                method_names,
+                receiver_id,
+                ..
+            } => Ok(Self::FunctionCall(FunctionCallPermission {
+                allowance: allowance.map(|a| parse_near_token(&a)).transpose()?,
+                receiver_id,
+                method_names,
+            })),
+            near_openrpc_client::AccessKeyPermissionView::GasKeyFullAccess { .. } => {
                 Ok(Self::FullAccess)
             }
         }

--- a/types/src/transaction/actions.rs
+++ b/types/src/transaction/actions.rs
@@ -249,12 +249,10 @@ pub struct AddGasKeyAction {
     pub permission: AccessKeyPermission,
 }
 
-
 #[derive(Serialize, Deserialize, Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct DeleteGasKeyAction {
     pub public_key: PublicKey,
 }
-
 
 #[derive(Serialize, Deserialize, Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct TransferToGasKeyAction {
@@ -368,9 +366,10 @@ impl TryFrom<near_openrpc_client::AccessKeyPermission> for AccessKeyPermission {
                 Ok(Self::FunctionCall(function_call_permission.try_into()?))
             }
             near_openrpc_client::AccessKeyPermission::FullAccess => Ok(Self::FullAccess),
-            near_openrpc_client::AccessKeyPermission::GasKeyFunctionCall(_, function_call_permission) => {
-                Ok(Self::FunctionCall(function_call_permission.try_into()?))
-            }
+            near_openrpc_client::AccessKeyPermission::GasKeyFunctionCall(
+                _,
+                function_call_permission,
+            ) => Ok(Self::FunctionCall(function_call_permission.try_into()?)),
             near_openrpc_client::AccessKeyPermission::GasKeyFullAccess(_) => Ok(Self::FullAccess),
         }
     }
@@ -482,7 +481,9 @@ impl TryFrom<near_openrpc_client::GlobalContractIdentifier> for GlobalContractId
 
 impl TryFrom<near_openrpc_client::GlobalContractIdentifierView> for GlobalContractIdentifier {
     type Error = DataConversionError;
-    fn try_from(val: near_openrpc_client::GlobalContractIdentifierView) -> Result<Self, Self::Error> {
+    fn try_from(
+        val: near_openrpc_client::GlobalContractIdentifierView,
+    ) -> Result<Self, Self::Error> {
         match val {
             near_openrpc_client::GlobalContractIdentifierView::Hash(code_hash) => {
                 Ok(Self::CodeHash(code_hash.try_into()?))
@@ -604,13 +605,12 @@ impl TryFrom<near_openrpc_client::ActionView> for Action {
                 public_key: public_key.try_into()?,
                 deposit: parse_near_token(&deposit)?,
             }))),
-            near_openrpc_client::ActionView::WithdrawFromGasKey {
-                amount,
-                public_key,
-            } => Ok(Self::TransferToGasKey(Box::new(TransferToGasKeyAction {
-                public_key: public_key.try_into()?,
-                deposit: parse_near_token(&amount)?,
-            }))),
+            near_openrpc_client::ActionView::WithdrawFromGasKey { amount, public_key } => {
+                Ok(Self::TransferToGasKey(Box::new(TransferToGasKeyAction {
+                    public_key: public_key.try_into()?,
+                    deposit: parse_near_token(&amount)?,
+                })))
+            }
         }
     }
 }

--- a/types/src/transaction/delegate_action.rs
+++ b/types/src/transaction/delegate_action.rs
@@ -96,9 +96,9 @@ impl TryFrom<near_openrpc_client::NonDelegateAction> for NonDelegateAction {
             near_openrpc_client::NonDelegateAction::DeleteKey(delete_key_action) => Ok(Self(
                 Action::DeleteKey(Box::new(delete_key_action.try_into()?)),
             )),
-            near_openrpc_client::NonDelegateAction::DeleteAccount(delete_account_action) => {
-                Ok(Self(Action::DeleteAccount(delete_account_action.try_into()?)))
-            }
+            near_openrpc_client::NonDelegateAction::DeleteAccount(delete_account_action) => Ok(
+                Self(Action::DeleteAccount(delete_account_action.try_into()?)),
+            ),
             near_openrpc_client::NonDelegateAction::DeployGlobalContract(
                 deploy_global_contract_action,
             ) => Ok(Self(Action::DeployGlobalContract(
@@ -109,11 +109,11 @@ impl TryFrom<near_openrpc_client::NonDelegateAction> for NonDelegateAction {
             ) => Ok(Self(Action::UseGlobalContract(Box::new(
                 use_global_contract_action.try_into()?,
             )))),
-            near_openrpc_client::NonDelegateAction::TransferToGasKey(transfer_to_gas_key_action) => {
-                Ok(Self(Action::TransferToGasKey(Box::new(
-                    transfer_to_gas_key_action.try_into()?,
-                ))))
-            }
+            near_openrpc_client::NonDelegateAction::TransferToGasKey(
+                transfer_to_gas_key_action,
+            ) => Ok(Self(Action::TransferToGasKey(Box::new(
+                transfer_to_gas_key_action.try_into()?,
+            )))),
             near_openrpc_client::NonDelegateAction::WithdrawFromGasKey(withdraw_action) => {
                 use crate::transaction::actions::{TransferToGasKeyAction, parse_near_token};
                 Ok(Self(Action::TransferToGasKey(Box::new(

--- a/types/src/transaction/delegate_action.rs
+++ b/types/src/transaction/delegate_action.rs
@@ -40,10 +40,10 @@ pub struct DelegateAction {
     pub public_key: PublicKey,
 }
 
-impl TryFrom<near_openapi_types::DelegateAction> for DelegateAction {
+impl TryFrom<near_openrpc_client::DelegateAction> for DelegateAction {
     type Error = DataConversionError;
-    fn try_from(value: near_openapi_types::DelegateAction) -> Result<Self, Self::Error> {
-        let near_openapi_types::DelegateAction {
+    fn try_from(value: near_openrpc_client::DelegateAction) -> Result<Self, Self::Error> {
+        let near_openrpc_client::DelegateAction {
             sender_id,
             receiver_id,
             actions,
@@ -53,8 +53,8 @@ impl TryFrom<near_openapi_types::DelegateAction> for DelegateAction {
         } = value;
 
         Ok(Self {
-            sender_id,
-            receiver_id,
+            sender_id: sender_id.parse()?,
+            receiver_id: receiver_id.parse()?,
             actions: actions
                 .into_iter()
                 .map(NonDelegateAction::try_from)
@@ -66,58 +66,61 @@ impl TryFrom<near_openapi_types::DelegateAction> for DelegateAction {
     }
 }
 
-impl TryFrom<near_openapi_types::NonDelegateAction> for NonDelegateAction {
+impl TryFrom<near_openrpc_client::NonDelegateAction> for NonDelegateAction {
     type Error = DataConversionError;
-    fn try_from(val: near_openapi_types::NonDelegateAction) -> Result<Self, Self::Error> {
+    fn try_from(val: near_openrpc_client::NonDelegateAction) -> Result<Self, Self::Error> {
         match val {
-            near_openapi_types::NonDelegateAction::DeterministicStateInit(
+            near_openrpc_client::NonDelegateAction::DeterministicStateInit(
                 deterministic_state_init,
             ) => Ok(Self(Action::DeterministicStateInit(Box::new(
                 deterministic_state_init.try_into()?,
             )))),
-            near_openapi_types::NonDelegateAction::CreateAccount(create_account_action) => {
+            near_openrpc_client::NonDelegateAction::CreateAccount(create_account_action) => {
                 Ok(Self(Action::CreateAccount(create_account_action.into())))
             }
-            near_openapi_types::NonDelegateAction::DeployContract(deploy_contract_action) => Ok(
+            near_openrpc_client::NonDelegateAction::DeployContract(deploy_contract_action) => Ok(
                 Self(Action::DeployContract(deploy_contract_action.try_into()?)),
             ),
-            near_openapi_types::NonDelegateAction::FunctionCall(function_call_action) => Ok(Self(
+            near_openrpc_client::NonDelegateAction::FunctionCall(function_call_action) => Ok(Self(
                 Action::FunctionCall(Box::new(function_call_action.try_into()?)),
             )),
-            near_openapi_types::NonDelegateAction::Transfer(transfer_action) => {
+            near_openrpc_client::NonDelegateAction::Transfer(transfer_action) => {
                 Ok(Self(Action::Transfer(transfer_action.try_into()?)))
             }
-            near_openapi_types::NonDelegateAction::Stake(stake_action) => {
+            near_openrpc_client::NonDelegateAction::Stake(stake_action) => {
                 Ok(Self(Action::Stake(Box::new(stake_action.try_into()?))))
             }
-            near_openapi_types::NonDelegateAction::AddKey(add_key_action) => {
+            near_openrpc_client::NonDelegateAction::AddKey(add_key_action) => {
                 Ok(Self(Action::AddKey(Box::new(add_key_action.try_into()?))))
             }
-            near_openapi_types::NonDelegateAction::DeleteKey(delete_key_action) => Ok(Self(
+            near_openrpc_client::NonDelegateAction::DeleteKey(delete_key_action) => Ok(Self(
                 Action::DeleteKey(Box::new(delete_key_action.try_into()?)),
             )),
-            near_openapi_types::NonDelegateAction::DeleteAccount(delete_account_action) => {
-                Ok(Self(Action::DeleteAccount(delete_account_action.into())))
+            near_openrpc_client::NonDelegateAction::DeleteAccount(delete_account_action) => {
+                Ok(Self(Action::DeleteAccount(delete_account_action.try_into()?)))
             }
-            near_openapi_types::NonDelegateAction::DeployGlobalContract(
+            near_openrpc_client::NonDelegateAction::DeployGlobalContract(
                 deploy_global_contract_action,
             ) => Ok(Self(Action::DeployGlobalContract(
                 deploy_global_contract_action.try_into()?,
             ))),
-            near_openapi_types::NonDelegateAction::UseGlobalContract(
+            near_openrpc_client::NonDelegateAction::UseGlobalContract(
                 use_global_contract_action,
             ) => Ok(Self(Action::UseGlobalContract(Box::new(
-                use_global_contract_action.into(),
+                use_global_contract_action.try_into()?,
             )))),
-            near_openapi_types::NonDelegateAction::AddGasKey(add_gas_key_action) => Ok(Self(
-                Action::AddGasKey(Box::new(add_gas_key_action.try_into()?)),
-            )),
-            near_openapi_types::NonDelegateAction::DeleteGasKey(delete_gas_key_action) => Ok(Self(
-                Action::DeleteGasKey(Box::new(delete_gas_key_action.try_into()?)),
-            )),
-            near_openapi_types::NonDelegateAction::TransferToGasKey(transfer_to_gas_key_action) => {
+            near_openrpc_client::NonDelegateAction::TransferToGasKey(transfer_to_gas_key_action) => {
                 Ok(Self(Action::TransferToGasKey(Box::new(
                     transfer_to_gas_key_action.try_into()?,
+                ))))
+            }
+            near_openrpc_client::NonDelegateAction::WithdrawFromGasKey(withdraw_action) => {
+                use crate::transaction::actions::{TransferToGasKeyAction, parse_near_token};
+                Ok(Self(Action::TransferToGasKey(Box::new(
+                    TransferToGasKeyAction {
+                        public_key: withdraw_action.public_key.try_into()?,
+                        deposit: parse_near_token(&withdraw_action.amount)?,
+                    },
                 ))))
             }
         }
@@ -130,10 +133,10 @@ pub struct SignedDelegateAction {
     pub signature: Signature,
 }
 
-impl TryFrom<near_openapi_types::SignedDelegateAction> for SignedDelegateAction {
+impl TryFrom<near_openrpc_client::SignedDelegateAction> for SignedDelegateAction {
     type Error = DataConversionError;
-    fn try_from(value: near_openapi_types::SignedDelegateAction) -> Result<Self, Self::Error> {
-        let near_openapi_types::SignedDelegateAction {
+    fn try_from(value: near_openrpc_client::SignedDelegateAction) -> Result<Self, Self::Error> {
+        let near_openrpc_client::SignedDelegateAction {
             delegate_action,
             signature,
         } = value;

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -119,11 +119,11 @@ pub struct SignedTransaction {
     hash: OnceLock<CryptoHash>,
 }
 
-impl TryFrom<near_openapi_types::SignedTransactionView> for SignedTransaction {
+impl TryFrom<near_openrpc_client::SignedTransactionView> for SignedTransaction {
     type Error = DataConversionError;
 
-    fn try_from(value: near_openapi_types::SignedTransactionView) -> Result<Self, Self::Error> {
-        let near_openapi_types::SignedTransactionView {
+    fn try_from(value: near_openrpc_client::SignedTransactionView) -> Result<Self, Self::Error> {
+        let near_openrpc_client::SignedTransactionView {
             signer_id,
             public_key,
             nonce,
@@ -132,7 +132,12 @@ impl TryFrom<near_openapi_types::SignedTransactionView> for SignedTransaction {
             priority_fee,
             hash,
             signature,
+            nonce_index: _,
         } = value;
+
+        let signer_id: AccountId = signer_id.parse()?;
+        let receiver_id: AccountId = receiver_id.parse()?;
+        let block_hash: CryptoHash = hash.try_into()?;
 
         let transaction = if priority_fee > 0 {
             Transaction::V1(TransactionV1 {
@@ -140,7 +145,7 @@ impl TryFrom<near_openapi_types::SignedTransactionView> for SignedTransaction {
                 public_key: public_key.try_into()?,
                 nonce,
                 receiver_id,
-                block_hash: hash.into(),
+                block_hash,
                 actions: actions
                     .into_iter()
                     .map(Action::try_from)
@@ -153,7 +158,7 @@ impl TryFrom<near_openapi_types::SignedTransactionView> for SignedTransaction {
                 public_key: public_key.try_into()?,
                 nonce,
                 receiver_id,
-                block_hash: hash.into(),
+                block_hash,
                 actions: actions
                     .into_iter()
                     .map(Action::try_from)
@@ -165,7 +170,7 @@ impl TryFrom<near_openapi_types::SignedTransactionView> for SignedTransaction {
     }
 }
 
-impl From<SignedTransaction> for near_openapi_types::SignedTransaction {
+impl From<SignedTransaction> for near_openrpc_client::SignedTransaction {
     fn from(transaction: SignedTransaction) -> Self {
         #[allow(clippy::expect_used)]
         let bytes = borsh::to_vec(&transaction).expect("Failed to serialize");

--- a/types/src/transaction/result.rs
+++ b/types/src/transaction/result.rs
@@ -4,8 +4,8 @@ use std::fmt;
 
 use base64::{Engine as _, engine::general_purpose};
 use borsh;
-use near_openapi_types::{
-    CallResult, ExecutionStatusView, FinalExecutionOutcomeView, FinalExecutionStatus,
+use near_openrpc_client::{
+    ExecutionStatusView, FinalExecutionOutcomeView, FinalExecutionStatus, RpcCallFunctionResponse,
     TxExecutionError, TxExecutionStatus,
 };
 
@@ -204,17 +204,17 @@ impl TryFrom<FinalExecutionOutcomeView> for ExecutionFinalResult {
             transaction_outcome,
         } = view;
 
-        let total_gas_burnt = transaction_outcome.outcome.gas_burnt.as_gas()
+        let total_gas_burnt = *transaction_outcome.outcome.gas_burnt
             + receipts_outcome
                 .iter()
-                .map(|t| t.outcome.gas_burnt.as_gas())
+                .map(|t| *t.outcome.gas_burnt)
                 .sum::<u64>();
 
-        let transaction_outcome = transaction_outcome.into();
+        let transaction_outcome = ExecutionOutcome::try_from(transaction_outcome)?;
         let receipts = receipts_outcome
             .into_iter()
-            .map(ExecutionOutcome::from)
-            .collect();
+            .map(ExecutionOutcome::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
 
         let total_gas_burnt = NearGas::from_gas(total_gas_burnt);
         Ok(Self {
@@ -610,8 +610,8 @@ impl ViewResultDetails {
     }
 }
 
-impl From<CallResult> for ViewResultDetails {
-    fn from(result: CallResult) -> Self {
+impl From<RpcCallFunctionResponse> for ViewResultDetails {
+    fn from(result: RpcCallFunctionResponse) -> Self {
         Self {
             result: result.result,
             logs: result.logs,
@@ -672,9 +672,9 @@ impl ExecutionOutcome {
             ExecutionStatusView::SuccessValue(value) => {
                 Ok(ValueOrReceiptId::Value(Value::from_string(value)))
             }
-            ExecutionStatusView::SuccessReceiptId(hash) => {
-                Ok(ValueOrReceiptId::ReceiptId(hash.into()))
-            }
+            ExecutionStatusView::SuccessReceiptId(hash) => Ok(ValueOrReceiptId::ReceiptId(
+                CryptoHash::try_from(hash).map_err(DataConversionError::from)?,
+            )),
             ExecutionStatusView::Failure(err) => {
                 Err(ExecutionError::TransactionExecutionFailed(Box::new(err)))
             }
@@ -734,28 +734,29 @@ impl Value {
     }
 }
 
-impl From<near_openapi_types::ExecutionOutcomeWithIdView> for ExecutionOutcome {
-    fn from(view: near_openapi_types::ExecutionOutcomeWithIdView) -> Self {
-        let near_openapi_types::ExecutionOutcomeWithIdView {
+impl TryFrom<near_openrpc_client::ExecutionOutcomeWithIdView> for ExecutionOutcome {
+    type Error = DataConversionError;
+    fn try_from(view: near_openrpc_client::ExecutionOutcomeWithIdView) -> Result<Self, Self::Error> {
+        let near_openrpc_client::ExecutionOutcomeWithIdView {
             id,
             block_hash,
             outcome,
             proof: _, // TODO: research if we need this
         } = view;
 
-        Self {
-            transaction_hash: id.into(),
-            block_hash: block_hash.into(),
+        Ok(Self {
+            transaction_hash: id.try_into()?,
+            block_hash: block_hash.try_into()?,
             logs: outcome.logs,
             receipt_ids: outcome
                 .receipt_ids
                 .into_iter()
-                .map(CryptoHash::from)
-                .collect(),
-            gas_burnt: outcome.gas_burnt,
-            tokens_burnt: outcome.tokens_burnt,
-            executor_id: outcome.executor_id,
+                .map(CryptoHash::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
+            gas_burnt: NearGas::from_gas(*outcome.gas_burnt),
+            tokens_burnt: NearToken::from_yoctonear(outcome.tokens_burnt.parse::<u128>()?),
+            executor_id: outcome.executor_id.parse()?,
             status: outcome.status,
-        }
+        })
     }
 }

--- a/types/src/transaction/result.rs
+++ b/types/src/transaction/result.rs
@@ -705,9 +705,9 @@ impl ExecutionOutcome {
             ExecutionStatusView::SuccessValue(value) => {
                 Ok(ValueOrReceiptId::Value(Value::from_string(value)))
             }
-            ExecutionStatusView::SuccessReceiptId(hash) => Ok(ValueOrReceiptId::ReceiptId(
-                CryptoHash::try_from(hash).map_err(DataConversionError::from)?,
-            )),
+            ExecutionStatusView::SuccessReceiptId(hash) => {
+                Ok(ValueOrReceiptId::ReceiptId(CryptoHash::try_from(hash)?))
+            }
             ExecutionStatusView::Failure(err) => {
                 Err(ExecutionError::TransactionExecutionFailed(Box::new(err)))
             }
@@ -769,7 +769,9 @@ impl Value {
 
 impl TryFrom<near_openrpc_client::ExecutionOutcomeWithIdView> for ExecutionOutcome {
     type Error = DataConversionError;
-    fn try_from(view: near_openrpc_client::ExecutionOutcomeWithIdView) -> Result<Self, Self::Error> {
+    fn try_from(
+        view: near_openrpc_client::ExecutionOutcomeWithIdView,
+    ) -> Result<Self, Self::Error> {
         let near_openrpc_client::ExecutionOutcomeWithIdView {
             id,
             block_hash,


### PR DESCRIPTION
## Summary
- Replace `near-openapi-client` / `near-openapi-types` with `near-openrpc-client` (OpenRPC-generated types and client)
- Update all type imports, query builders, transaction handling, and error types across both `api` and `types` crates
- Remove duplicated `RpcError`/`RpcErrorCause` from `rpc_client.rs` — now imported from `near_openrpc_client::errors`
- Simplify retry logic in `utils.rs` to use `RpcError::is_retryable()` and `try_cause_as::<RpcTransactionError>()` instead of string-matching cause names
- Add `SendRequestError::try_cause_as<T>()` convenience for downstream typed error matching
- Re-export `near_openrpc_client::errors` as `near_api::rpc_errors`
- Port `TransactionStatusRpc`, `ReceiptRpc`, and `TransactionProofRpc` to use the openrpc `RpcClient`
- Port error criticality functions (`is_critical_transaction_status_error`, `is_critical_receipt_error`, `is_critical_light_client_proof_error`) to use unified `RpcError` approach

## Dependencies
- near/near-openrpc-client-rs#9 (errors module, needs to merge first — currently pointing to branch)

## Test plan
- [x] `cargo check` passes
- [x] `cargo test --lib` passes (40 tests)
- [x] `cargo doc --no-deps` builds
- [x] Merged with latest main (resolved conflicts from #126, #130, #136, #138, #140)
- [ ] Update `Cargo.toml` git dep to point to main after near/near-openrpc-client-rs#9 merges
- [ ] Full integration test suite