### PR TITLE
chore: bump near-primitives and near-crypto dev-deps to 0.35

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,8 @@ near-openapi-client = "0.8"
 near-openapi-types = "0.8"
 
 # Dev-dependencies
-near-primitives = { version = "0.35.0-rc.5" }
-near-crypto = { version = "0.35.0-rc.5" }
+near-primitives = { version = "0.35" }
+near-crypto = { version = "0.35" }
 near-sandbox = { version = "0.3.7", features = [
     "generate",
 ], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,8 @@ near-openapi-client = "0.8"
 near-openapi-types = "0.8"
 
 # Dev-dependencies
-near-primitives = { version = "0.34" }
-near-crypto = { version = "0.34" }
+near-primitives = { version = "0.35.0-rc.5" }
+near-crypto = { version = "0.35.0-rc.5" }
 near-sandbox = { version = "0.3.7", features = [
     "generate",
 ], default-features = false }


### PR DESCRIPTION
- Bump near-primitives and near-crypto dev-dependencies from 0.34 to 0.35 for the 2.11.0 mainnet release
- These are dev-only deps (used in tests), so no public API impact