### PR TITLE
chore: release v0.8.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["api", "types"]
 [workspace.package]
 rust-version = "1.86"
 edition = "2024"
-version = "0.8.5"
+version = "0.8.6"
 authors = [
     "akorchyn <artur.yurii.korchynskyi@gmail.com>",
     "frol <frolvlad@gmail.com>",
@@ -16,7 +16,7 @@ repository = "https://github.com/near/near-api-rs"
 
 
 [workspace.dependencies]
-near-api-types = { path = "types", version = "~0.8.5" }
+near-api-types = { path = "types", version = "~0.8.6" }
 
 borsh = "1.5"
 async-trait = "0.1"

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.6](https://github.com/near/near-api-rs/compare/near-api-v0.8.5...near-api-v0.8.6) - 2026-04-15
+
+### Other
+
+- changed `slipped10` to `near-slip10` ([#143](https://github.com/near/near-api-rs/pull/143))
+
 ## [0.8.5](https://github.com/near/near-api-rs/compare/near-api-v0.8.4...near-api-v0.8.5) - 2026-03-05
 
 ### Other

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.6](https://github.com/near/near-api-rs/compare/near-api-types-v0.8.5...near-api-types-v0.8.6) - 2026-04-15
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.8.5](https://github.com/near/near-api-rs/compare/near-api-types-v0.8.4...near-api-types-v0.8.5) - 2026-03-05
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `near-api-types`: 0.8.5 -> 0.8.6 (✓ API compatible changes)
* `near-api`: 0.8.5 -> 0.8.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-api-types`

<blockquote>

## [0.8.6](https://github.com/near/near-api-rs/compare/near-api-types-v0.8.5...near-api-types-v0.8.6) - 2026-04-15

### Other

- update Cargo.toml dependencies
</blockquote>

## `near-api`

<blockquote>

## [0.8.6](https://github.com/near/near-api-rs/compare/near-api-v0.8.5...near-api-v0.8.6) - 2026-04-15

### Other

- changed `slipped10` to `near-slip10` ([#143](https://github.com/near/near-api-rs/pull/143))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).