### PR TITLE
chore: changed `slipped10` to `near-slip10`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ bip39 = "2.0.0"
 serde = { version = "1.0", features = ["derive"], default-features = false }
 serde_json = "1.0.57"
 serde_dbgfmt = "0.1.0"
-slipped10 = { version = "0.4.6" }
+near-slip10 = { version = "0.4.7" }
 url = { version = "2", features = ["serde"] }
 tokio = { version = "1.0", default-features = false }
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ near-account-id = { version = "2.0.0", features = ["serde", "borsh"] }
 near-gas = { version = "0.3", features = ["serde", "borsh"] }
 near-token = { version = "0.3", features = ["serde", "borsh"] }
 near-abi = "0.4.2"
-near-ledger = "0.9.1"
+near-ledger = "0.9.3"
 near-openapi-client = "0.8"
 near-openapi-types = "0.8"
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -28,7 +28,7 @@ bip39 = { workspace = true, features = ["rand"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_dbgfmt.workspace = true
-slipped10.workspace = true
+near-slip10.workspace = true
 url.workspace = true
 tokio = { workspace = true, default-features = false, features = ["time"] }
 tracing.workspace = true

--- a/api/src/signer/ledger.rs
+++ b/api/src/signer/ledger.rs
@@ -6,7 +6,7 @@ use near_api_types::{
         delegate_action::{DelegateAction, NonDelegateAction, SignedDelegateAction},
     },
 };
-use slipped10::BIP32Path;
+use near_slip10::BIP32Path;
 use tokio::sync::OnceCell;
 use tracing::{debug, info, instrument, warn};
 

--- a/api/src/signer/mod.rs
+++ b/api/src/signer/mod.rs
@@ -124,8 +124,8 @@ use near_api_types::{
 };
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use near_slip10::BIP32Path;
 use serde::{Deserialize, Serialize};
-use slipped10::BIP32Path;
 use tracing::{debug, instrument, warn};
 
 use crate::{
@@ -765,9 +765,9 @@ pub fn get_secret_key_from_seed(
 ) -> Result<SecretKey, SecretError> {
     let master_seed =
         bip39::Mnemonic::parse(master_seed_phrase)?.to_seed(password.unwrap_or_default());
-    let derived_private_key = slipped10::derive_key_from_path(
+    let derived_private_key = near_slip10::derive_key_from_path(
         &master_seed,
-        slipped10::Curve::Ed25519,
+        near_slip10::Curve::Ed25519,
         &seed_phrase_hd_path,
     )
     .map_err(|_| SecretError::DeriveKeyInvalidIndex)?;


### PR DESCRIPTION
Changing `slipped10` to `near-slip10` due to possible supply chain attack.

Related links:
original slack discussion/report: https://nearone.slack.com/archives/C0A64SAMDNG/p1776266170753839

Should be merged after https://github.com/near/near-ledger-rs/pull/32