### PR TITLE
chore: release v0.8.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["api", "types"]
 [workspace.package]
 rust-version = "1.86"
 edition = "2024"
-version = "0.8.6"
+version = "0.8.7"
 authors = [
     "akorchyn <artur.yurii.korchynskyi@gmail.com>",
     "frol <frolvlad@gmail.com>",
@@ -16,7 +16,7 @@ repository = "https://github.com/near/near-api-rs"
 
 
 [workspace.dependencies]
-near-api-types = { path = "types", version = "~0.8.6" }
+near-api-types = { path = "types", version = "~0.8.7" }
 
 borsh = "1.5"
 async-trait = "0.1"

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.7](https://github.com/near/near-api-rs/compare/near-api-v0.8.6...near-api-v0.8.7) - 2026-05-08
+
+### Added
+
+- update function call max_gas to 1000 TGas ([#120](https://github.com/near/near-api-rs/pull/120))
+
 ## [0.8.6](https://github.com/near/near-api-rs/compare/near-api-v0.8.5...near-api-v0.8.6) - 2026-04-15
 
 ### Other

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.7](https://github.com/near/near-api-rs/compare/near-api-v0.8.6...near-api-v0.8.7) - 2026-07-13
+
+### Added
+
+- update function call max_gas to 1000 TGas ([#120](https://github.com/near/near-api-rs/pull/120))
+
+### Fixed
+
+- retry on transient communication and response errors ([#145](https://github.com/near/near-api-rs/pull/145))
+
 ## [0.8.6](https://github.com/near/near-api-rs/compare/near-api-v0.8.5...near-api-v0.8.6) - 2026-04-15
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `near-api-types`: 0.8.6 -> 0.8.7
* `near-api`: 0.8.6 -> 0.8.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `near-api-types`

<blockquote>

## [0.8.6](https://github.com/near/near-api-rs/compare/near-api-types-v0.8.5...near-api-types-v0.8.6) - 2026-04-15

### Other

- update Cargo.toml dependencies
</blockquote>

## `near-api`

<blockquote>

## [0.8.7](https://github.com/near/near-api-rs/compare/near-api-v0.8.6...near-api-v0.8.7) - 2026-07-13

### Added

- update function call max_gas to 1000 TGas ([#120](https://github.com/near/near-api-rs/pull/120))

### Fixed

- retry on transient communication and response errors ([#145](https://github.com/near/near-api-rs/pull/145))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).