### PR TITLE
docs(examples): enable default tracing

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -57,3 +57,4 @@ keystore = ["dep:keyring"]
 tokio = { workspace = true, default-features = false, features = ["full"] }
 near-sandbox = { workspace = true, features = ["generate"] }
 testresult.workspace = true
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/api/example_utils.rs
+++ b/api/example_utils.rs
@@ -1,0 +1,6 @@
+pub fn init_tracing() {
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("near_api=trace"));
+
+    tracing_subscriber::fmt().with_env_filter(filter).init();
+}

--- a/api/examples/account_key_pooling.rs
+++ b/api/examples/account_key_pooling.rs
@@ -1,3 +1,6 @@
+#[path = "../example_utils.rs"]
+mod common;
+
 /// You can use account key pooling to use different keys for consecutive transactions
 /// to avoid nonce-related issues.
 ///
@@ -18,6 +21,8 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> TestResult {
+    common::init_tracing();
+
     let account: AccountId = DEFAULT_GENESIS_ACCOUNT.into();
     let second_account = GenesisAccount::generate_with_name("second_account".parse()?);
 

--- a/api/examples/contract_source_metadata.rs
+++ b/api/examples/contract_source_metadata.rs
@@ -1,3 +1,6 @@
+#[path = "../example_utils.rs"]
+mod common;
+
 use std::str::FromStr;
 
 use near_api::{Contract, types::AccountId};
@@ -5,6 +8,8 @@ use testresult::TestResult;
 
 #[tokio::main]
 async fn main() -> TestResult {
+    common::init_tracing();
+
     for (account_name, expected_json_metadata) in [
         ("desolate-toad.testnet", FIRST_METADATA),
         ("fat-fabulous-toad.testnet", SECOND_METADATA),

--- a/api/examples/create_account_and_send_near.rs
+++ b/api/examples/create_account_and_send_near.rs
@@ -1,3 +1,6 @@
+#[path = "../example_utils.rs"]
+mod common;
+
 use near_api::{
     Account, NetworkConfig, Signer, Tokens,
     signer::generate_secret_key,
@@ -8,6 +11,8 @@ use testresult::TestResult;
 
 #[tokio::main]
 async fn main() -> TestResult {
+    common::init_tracing();
+
     let network = near_sandbox::Sandbox::start_sandbox().await?;
 
     let network = NetworkConfig::from_rpc_url("sandbox", network.rpc_addr.parse()?);

--- a/api/examples/deploy_and_call_method.rs
+++ b/api/examples/deploy_and_call_method.rs
@@ -1,3 +1,6 @@
+#[path = "../example_utils.rs"]
+mod common;
+
 use near_api::{
     Contract, NetworkConfig, Signer,
     types::{AccountId, Data},
@@ -7,6 +10,8 @@ use testresult::TestResult;
 
 #[tokio::main]
 async fn main() -> TestResult {
+    common::init_tracing();
+
     let network = near_sandbox::Sandbox::start_sandbox().await.unwrap();
     let account: AccountId = DEFAULT_GENESIS_ACCOUNT.into();
     let network = NetworkConfig::from_rpc_url("sandbox", network.rpc_addr.parse().unwrap());

--- a/api/examples/ft.rs
+++ b/api/examples/ft.rs
@@ -1,3 +1,6 @@
+#[path = "../example_utils.rs"]
+mod common;
+
 use near_api::{
     Contract, NetworkConfig, Signer, Tokens,
     types::{AccountId, tokens::FTBalance},
@@ -9,6 +12,8 @@ use testresult::TestResult;
 
 #[tokio::main]
 async fn main() -> TestResult {
+    common::init_tracing();
+
     let token = GenesisAccount::generate_with_name("token".parse()?);
     let account: AccountId = DEFAULT_GENESIS_ACCOUNT.into();
     let token_signer = Signer::from_secret_key(token.private_key.clone().parse()?)?;

--- a/api/examples/global_deploy.rs
+++ b/api/examples/global_deploy.rs
@@ -1,8 +1,13 @@
+#[path = "../example_utils.rs"]
+mod common;
+
 use near_api::{Contract, NetworkConfig, Signer, types::CryptoHash};
 use near_sandbox::{GenesisAccount, SandboxConfig};
 
 #[tokio::main]
 async fn main() -> testresult::TestResult {
+    common::init_tracing();
+
     let global = GenesisAccount::generate_with_name("global".parse()?);
     let instance_of_global = GenesisAccount::generate_with_name("instance_of_global".parse()?);
     let sandbox = near_sandbox::Sandbox::start_sandbox_with_config(SandboxConfig {

--- a/api/examples/nep_413_signing_message.rs
+++ b/api/examples/nep_413_signing_message.rs
@@ -1,3 +1,6 @@
+#[path = "../example_utils.rs"]
+mod common;
+
 use near_api::{NetworkConfig, Signer};
 
 use near_sandbox::config::{DEFAULT_GENESIS_ACCOUNT, DEFAULT_GENESIS_ACCOUNT_PRIVATE_KEY};
@@ -5,6 +8,8 @@ use openssl::rand::rand_bytes;
 
 #[tokio::main]
 async fn main() -> testresult::TestResult {
+    common::init_tracing();
+
     let sandbox = near_sandbox::Sandbox::start_sandbox().await?;
     let network = NetworkConfig::from_rpc_url("sandbox", sandbox.rpc_addr.parse()?);
 

--- a/api/examples/nft.rs
+++ b/api/examples/nft.rs
@@ -1,3 +1,6 @@
+#[path = "../example_utils.rs"]
+mod common;
+
 use near_api::{
     Contract, NetworkConfig, Signer, Tokens,
     types::{AccountId, NearToken, nft::TokenMetadata},
@@ -10,6 +13,8 @@ use serde_json::json;
 
 #[tokio::main]
 async fn main() -> testresult::TestResult {
+    common::init_tracing();
+
     let nft = GenesisAccount::generate_with_name("nft".parse()?);
     let account: AccountId = DEFAULT_GENESIS_ACCOUNT.into();
     let account2 = GenesisAccount::generate_with_name("account2".parse()?);

--- a/api/examples/sign_options.rs
+++ b/api/examples/sign_options.rs
@@ -1,3 +1,6 @@
+#[path = "../example_utils.rs"]
+mod common;
+
 use std::str::FromStr;
 
 use near_api::{
@@ -12,6 +15,8 @@ use near_sandbox::config::{
 
 #[tokio::main]
 async fn main() -> testresult::TestResult {
+    common::init_tracing();
+
     let network = near_sandbox::Sandbox::start_sandbox().await?;
     let account: AccountId = DEFAULT_GENESIS_ACCOUNT.into();
     let network = NetworkConfig::from_rpc_url("sandbox", network.rpc_addr.parse()?);

--- a/api/examples/specify_backup_rpc.rs
+++ b/api/examples/specify_backup_rpc.rs
@@ -1,7 +1,12 @@
+#[path = "../example_utils.rs"]
+mod common;
+
 use near_api::{Chain, NetworkConfig, RPCEndpoint, types::Reference};
 
 #[tokio::main]
 async fn main() -> testresult::TestResult {
+    common::init_tracing();
+
     let mut network = NetworkConfig::mainnet();
     network.rpc_endpoints.push(
         RPCEndpoint::new("https://near.lava.build:443".parse()?)

--- a/api/examples/specifying_block.rs
+++ b/api/examples/specifying_block.rs
@@ -1,7 +1,12 @@
+#[path = "../example_utils.rs"]
+mod common;
+
 use near_api::{Chain, types::Reference};
 
 #[tokio::main]
 async fn main() -> testresult::TestResult {
+    common::init_tracing();
+
     // Fetch a optimistic block
     let _optimistic_block = Chain::block().fetch_from_mainnet().await?;
 

--- a/api/examples/staking_example.rs
+++ b/api/examples/staking_example.rs
@@ -1,3 +1,6 @@
+#[path = "../example_utils.rs"]
+mod common;
+
 use std::sync::Arc;
 
 use near_api::{AccountId, NearToken, NetworkConfig, RPCEndpoint, Signer, Staking};
@@ -7,6 +10,8 @@ use near_sandbox::{
 
 #[tokio::main]
 async fn main() -> testresult::TestResult {
+    common::init_tracing();
+
     let staker: AccountId = "dev.near".parse()?;
     let sandbox = near_sandbox::Sandbox::start_sandbox().await?;
     let network = near_api::NetworkConfig::from_rpc_url("sandbox", sandbox.rpc_addr.parse()?);

--- a/api/examples/storage_management.rs
+++ b/api/examples/storage_management.rs
@@ -1,3 +1,6 @@
+#[path = "../example_utils.rs"]
+mod common;
+
 use near_api::{
     AccountId, Contract, NearToken, NetworkConfig, RPCEndpoint, Signer, StorageDeposit,
 };
@@ -5,6 +8,8 @@ use near_sandbox::config::DEFAULT_GENESIS_ACCOUNT_PRIVATE_KEY;
 
 #[tokio::main]
 async fn main() -> testresult::TestResult {
+    common::init_tracing();
+
     let account: AccountId = "dev.near".parse()?;
     let token: AccountId = "wrap.near".parse()?;
 

--- a/api/examples/transaction_queries.rs
+++ b/api/examples/transaction_queries.rs
@@ -1,3 +1,6 @@
+#[path = "../example_utils.rs"]
+mod common;
+
 use near_api::{
     Chain, Transaction,
     types::{AccountId, CryptoHash, Reference, TxExecutionStatus},
@@ -14,6 +17,8 @@ use testresult::TestResult;
 ///   TX_SENDER — the sender account ID
 #[tokio::main]
 async fn main() -> TestResult {
+    common::init_tracing();
+
     if std::env::var("CI").is_ok() {
         println!("Skipping transaction_queries in CI (requires mainnet)");
         return Ok(());


### PR DESCRIPTION
Closes #40.

## What changed

- add a shared tracing initializer for the examples
- enable `near_api=trace` by default so library instrumentation is visible
- honor `RUST_LOG` when callers want a different filter
- initialize tracing in every current example

The shared helper lives outside `api/examples/` so `run_all.sh` does not mistake it for an executable example, while path-based module imports also keep the example included in library doctests working.

## Impact

Running an example now shows the library's tracing events without additional setup, while preserving user control through `RUST_LOG`.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --examples --all-features`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `CI=true api/examples/run_all.sh`
- `env -u RUST_LOG cargo run -q -p near-api --example contract_source_metadata` (confirmed `DEBUG` and `TRACE` output)